### PR TITLE
Enable `CDE` bit in `henvcfg`

### DIFF
--- a/src/h_extension/csrs.rs
+++ b/src/h_extension/csrs.rs
@@ -271,6 +271,18 @@ pub mod henvcfg {
         }
     }
 
+    /// set CDE (60 bit)
+    pub fn set_cde() {
+        unsafe {
+            core::arch::asm!(
+                "
+                csrs henvcfg, {bits}
+                ",
+                bits = in(reg) 1u64 << 60
+            );
+        }
+    }
+
     /// set CBZE (7 bit)
     pub fn set_cbze() {
         unsafe {

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -50,6 +50,7 @@ pub extern "C" fn hstart(hart_id: usize, dtb_addr: usize) -> ! {
 
     // enable Sstc extention
     henvcfg::set_stce();
+    henvcfg::set_cde();
     henvcfg::set_cbze();
     henvcfg::set_cbcfe();
 


### PR DESCRIPTION
This fixes a bug that caused an exception when executing the `rdtime` instruction.
- add `henvcfg::set_cde`.
- remove `virtual_instruction_handler`.