### PR TITLE
Fix rust toolchain version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ fdt = "0.1.5"
 linked_list_allocator = "0.10.5"
 raki = "1.2.0"
 riscv = "0.11.1"
-riscv-rt = "0.11.0"
+riscv-rt = { git = "https://github.com/Alignof/riscv", branch = "fix/link_error_on_latest_rust" }
 rustsbi = { version = "0.4.0-alpha.1", features = ["machine"] }
 sbi-rt = "0.0.3"
 sbi-spec = { version = "0.0.7", features = [ "legacy" ] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.81.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "riscv64imac-unknown-none-elf" ]


### PR DESCRIPTION
- Fix riscv-rt linking bug (https://github.com/Alignof/riscv/tree/fix/link_error_on_latest_rust).
- Update Rust version (1.76.0 -> 1.81.0)