### PR TITLE
Change hypervisor CSR struct format

### DIFF
--- a/src/device/iommu.rs
+++ b/src/device/iommu.rs
@@ -40,7 +40,7 @@ impl IoMmu {
 
             unsafe {
                 core::ptr::write_volatile(tc_addr.0 as *mut u64, 1);
-                core::ptr::write_volatile(iohgatp_addr.0 as *mut u64, hgatp::read().bits as u64);
+                core::ptr::write_volatile(iohgatp_addr.0 as *mut u64, hgatp::read().bits() as u64);
             }
         }
     }

--- a/src/trap/hypervisor_supervisor/exception/page_fault_handler.rs
+++ b/src/trap/hypervisor_supervisor/exception/page_fault_handler.rs
@@ -13,8 +13,8 @@ use raki::Instruction;
 
 /// Trap `Load guest page fault` exception.
 pub fn load_guest_page_fault() {
-    let fault_addr = HostPhysicalAddress(htval::read().bits << 2);
-    let fault_inst_value = htinst::read().bits;
+    let fault_addr = HostPhysicalAddress(htval::read().bits() << 2);
+    let fault_inst_value = htinst::read().bits();
     // htinst bit 1 replaced with a 0.
     // thus it needed to flip bit 1.
     // ref: vol. II p.161
@@ -44,8 +44,8 @@ pub fn load_guest_page_fault() {
 
 /// Trap `Store guest page fault` exception.
 pub fn store_guest_page_fault() {
-    let fault_addr = HostPhysicalAddress(htval::read().bits << 2);
-    let fault_inst_value = htinst::read().bits;
+    let fault_addr = HostPhysicalAddress(htval::read().bits() << 2);
+    let fault_inst_value = htinst::read().bits();
     // htinst bit 1 replaced with a 0.
     // thus it needed to flip bit 1.
     // ref: vol. II p.161


### PR DESCRIPTION
Change struct format of hypervisor CSR to tuple struct.
## Before
```rust
pub struct Vstvec {
    /// bitmap
    bits: usize,
}
```

## After
```rust
pub struct Vstvec(usize);
```

Fix #40.