### PR TITLE
Use const operands in asm macro

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "riscv64imac-unknown-none-elf" ]

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -44,8 +44,7 @@ impl Guest {
         guest_dtb: &'static [u8; include_bytes!("../guest.dtb").len()],
         memory_region: Range<GuestPhysicalAddress>,
     ) -> Self {
-        let stack_top_addr =
-            HostPhysicalAddress(core::ptr::addr_of!(crate::_stack_start) as usize);
+        let stack_top_addr = HostPhysicalAddress(core::ptr::addr_of!(crate::_stack_start) as usize);
         let page_table_addr = HostPhysicalAddress(root_page_table.as_ptr() as usize);
 
         page_table::sv39x4::initialize_page_table(page_table_addr);

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -45,7 +45,7 @@ impl Guest {
         memory_region: Range<GuestPhysicalAddress>,
     ) -> Self {
         let stack_top_addr =
-            unsafe { HostPhysicalAddress(core::ptr::addr_of!(crate::_stack_start) as usize) };
+            HostPhysicalAddress(core::ptr::addr_of!(crate::_stack_start) as usize);
         let page_table_addr = HostPhysicalAddress(root_page_table.as_ptr() as usize);
 
         page_table::sv39x4::initialize_page_table(page_table_addr);

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -2,8 +2,8 @@
 
 use crate::device::MmioDevice;
 use crate::emulate_extension;
-use crate::guest::Guest;
 use crate::guest::context::ContextData;
+use crate::guest::Guest;
 use crate::h_extension::csrs::{
     hcounteren, hedeleg, hedeleg::ExceptionKind, henvcfg, hgatp, hideleg, hie, hstateen0, hstatus,
     hvip, vsatp, VsInterruptKind,

--- a/src/trap/hypervisor_supervisor.rs
+++ b/src/trap/hypervisor_supervisor.rs
@@ -3,9 +3,9 @@
 mod exception;
 mod interrupt;
 
+use crate::guest::context::ContextData;
 use exception::trap_exception;
 use interrupt::trap_interrupt;
-use crate::guest::context::ContextData;
 
 use crate::HYPERVISOR_DATA;
 use core::arch::asm;

--- a/src/trap/machine.rs
+++ b/src/trap/machine.rs
@@ -9,6 +9,7 @@ use interrupt::trap_interrupt;
 use core::arch::asm;
 use riscv::register::mcause::{self, Trap};
 
+/// Size of context data in M-mode.
 const MACHINE_CONTEXT_SIZE: usize = 256;
 
 /// Epilogue of Machine trap vector


### PR DESCRIPTION
- Update rust toolchain version.
- Replace the immediate values in the asm macro with constants.

Fix #58.