### PR TITLE
Modify `print` macro to use sbi calling

### DIFF
--- a/src/device/uart.rs
+++ b/src/device/uart.rs
@@ -16,25 +16,6 @@ mod register {
     pub const LSR_OFFSET: usize = 3;
 }
 
-/// Print to standard output.
-#[macro_export]
-macro_rules! print {
-    ($($arg:tt)*) => ($crate::device::uart::_print(format_args!($($arg)*)));
-}
-
-/// Print with linebreak to standard output.
-#[macro_export]
-macro_rules! println {
-    ($fmt:expr) => (print!(concat!($fmt, "\n")));
-    ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
-}
-
-/// Print function calling from print macro
-pub fn _print(args: fmt::Arguments) {
-    let mut writer = UartWriter {};
-    writer.write_fmt(args).unwrap();
-}
-
 /// Uart address for `UartWriter`.
 static UART_ADDR: Mutex<OnceCell<HostPhysicalAddress>> = Mutex::new(OnceCell::new());
 

--- a/src/device/uart.rs
+++ b/src/device/uart.rs
@@ -4,7 +4,6 @@ use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
 use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
 
 use core::cell::OnceCell;
-use core::fmt::{self, Write};
 use fdt::Fdt;
 use rustsbi::{Physical, SbiRet};
 use spin::Mutex;
@@ -18,24 +17,6 @@ mod register {
 
 /// Uart address for `UartWriter`.
 static UART_ADDR: Mutex<OnceCell<HostPhysicalAddress>> = Mutex::new(OnceCell::new());
-
-/// Struct for `Write` trait.
-struct UartWriter;
-
-impl Write for UartWriter {
-    /// Write string to tty via UART.
-    #[allow(clippy::cast_possible_wrap)]
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        let uart_addr = UART_ADDR.lock().get().unwrap().raw() as *mut u32;
-        for c in s.bytes() {
-            unsafe {
-                while (uart_addr.read_volatile() as i32) < 0 {}
-                uart_addr.write_volatile(u32::from(c));
-            }
-        }
-        Ok(())
-    }
-}
 
 /// UART: Universal asynchronous receiver-transmitter
 #[derive(Debug)]

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -24,6 +24,8 @@ use riscv::register::{sepc, sie, sscratch, sstatus, sstatus::FS, stvec};
 /// Entry point to HS-mode.
 #[inline(never)]
 pub extern "C" fn hstart(hart_id: usize, dtb_addr: usize) -> ! {
+    crate::println!("welcome to hikami");
+
     // hart_id must be zero.
     assert_eq!(hart_id, 0);
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,35 @@
+//! Print macros for logging
+
+use core::fmt::{self, Write};
+use sbi_rt::Physical;
+
+struct Writer;
+impl core::fmt::Write for Writer {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        sbi_rt::console_write(Physical::new(
+            s.len(),
+            s.as_ptr() as usize & 0xffff_ffff,
+            (s.as_ptr() as usize >> 32) & 0xffff_ffff,
+        ));
+        Ok(())
+    }
+}
+
+/// Print function calling from print macro
+pub fn _print(args: fmt::Arguments) {
+    let mut writer = Writer;
+    writer.write_fmt(args).unwrap();
+}
+
+/// Print to standard output.
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => ($crate::log::_print(format_args!($($arg)*)));
+}
+
+/// Print with linebreak to standard output.
+#[macro_export]
+macro_rules! println {
+    ($fmt:expr) => (crate::print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => (crate::print!(concat!($fmt, "\n"), $($arg)*));
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -3,6 +3,7 @@
 use core::fmt::{self, Write};
 use sbi_rt::Physical;
 
+/// Writer for print macro.
 struct Writer;
 impl core::fmt::Write for Writer {
     fn write_str(&mut self, s: &str) -> fmt::Result {
@@ -16,7 +17,7 @@ impl core::fmt::Write for Writer {
 }
 
 /// Print function calling from print macro
-pub fn _print(args: fmt::Arguments) {
+pub fn print_for_macro(args: fmt::Arguments) {
     let mut writer = Writer;
     writer.write_fmt(args).unwrap();
 }
@@ -24,12 +25,12 @@ pub fn _print(args: fmt::Arguments) {
 /// Print to standard output.
 #[macro_export]
 macro_rules! print {
-    ($($arg:tt)*) => ($crate::log::_print(format_args!($($arg)*)));
+    ($($arg:tt)*) => ($crate::log::print_for_macro(format_args!($($arg)*)));
 }
 
 /// Print with linebreak to standard output.
 #[macro_export]
 macro_rules! println {
-    ($fmt:expr) => (crate::print!(concat!($fmt, "\n")));
-    ($fmt:expr, $($arg:tt)*) => (crate::print!(concat!($fmt, "\n"), $($arg)*));
+    ($fmt:expr) => ($crate::print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => ($crate::print!(concat!($fmt, "\n"), $($arg)*));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
 #![no_std]
 // TODO: remove nightly when `naked_functions` become stable.
 #![feature(naked_functions)]
+// TODO: FIX AND REMOVE IT!!!
+#![allow(static_mut_refs)]
 
 extern crate alloc;
 mod device;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod emulate_extension;
 mod guest;
 mod h_extension;
 mod hypervisor_init;
+mod log;
 mod memmap;
 mod trap;
 


### PR DESCRIPTION
- Modify `print` macro to use sbi calling.
- Add log.rs
- Allow `static_mut_refs` lint rule **temporarily** (for CI)

Fix #8 