### PR TITLE
Fix emulation of writing data to SATA device

### DIFF
--- a/src/device/pci/sata.rs
+++ b/src/device/pci/sata.rs
@@ -153,7 +153,7 @@ impl HbaPort {
         let cmd_header_hpa = cmd_list_hpa + cmd_num as usize * COMMAND_HEADER_SIZE;
         let cmd_header_ptr = cmd_header_hpa.raw() as *mut CommandHeader;
         let prdtl = unsafe { (*cmd_header_ptr).prdtl() };
-        let transfer_dir = if unsafe { (*cmd_header_ptr).w() } == 0 {
+        let transfer_dir = if unsafe { (*cmd_header_ptr).w_bit() } == 0 {
             TransferDirection::DeviceToHost
         } else {
             TransferDirection::HostToDevice
@@ -197,7 +197,7 @@ impl HbaPort {
         };
         let cmd_header_hpa = cmd_list_hpa + cmd_num as usize * COMMAND_HEADER_SIZE;
         let cmd_header_ptr = cmd_header_hpa.raw() as *mut CommandHeader;
-        let transfer_dir = if unsafe { (*cmd_header_ptr).w() } == 0 {
+        let transfer_dir = if unsafe { (*cmd_header_ptr).w_bit() } == 0 {
             TransferDirection::DeviceToHost
         } else {
             TransferDirection::HostToDevice

--- a/src/device/pci/sata/command.rs
+++ b/src/device/pci/sata/command.rs
@@ -72,7 +72,8 @@ impl CommandHeader {
     pub fn prdtl(&self) -> u32 {
         (self.dw0 >> 16) & 0xffff
     }
-    pub fn w(&self) -> u32 {
+    /// get `w` bit value from `CommandHeader.dw0`
+    pub fn w_bit(&self) -> u32 {
         (self.dw0 >> 6) & 0x1
     }
 }

--- a/src/device/pci/sata/command.rs
+++ b/src/device/pci/sata/command.rs
@@ -130,7 +130,7 @@ impl PhysicalRegionDescriptor {
 
                         core::ptr::copy(
                             dst_hpa.raw() as *const u8,
-                            heap_ptr.add(offset) as *mut u8,
+                            heap_ptr.add(offset),
                             if offset + PAGE_SIZE < new_heap.len() {
                                 PAGE_SIZE
                             } else {

--- a/src/device/pci/sata/command.rs
+++ b/src/device/pci/sata/command.rs
@@ -8,6 +8,14 @@ use alloc::vec::Vec;
 /// Size of command header
 pub const COMMAND_HEADER_SIZE: usize = 0x20;
 
+/// Transfer direction
+pub enum TransferDirection {
+    /// Device to Host (Read).
+    DeviceToHost,
+    /// Host to Device (Write).
+    HostToDevice,
+}
+
 /// Address of command table to be saved.
 #[derive(Debug, Clone)]
 pub enum CommandTableAddressData {


### PR DESCRIPTION
- Add `TransferDirection`
- Add a process to copy guest memory data to allocated memory if the command is 'write'.