### PR TITLE
Remove unused implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ fdt = "0.1.5"
 linked_list_allocator = "0.10.5"
 raki = "1.3.1"
 riscv = "0.11.1"
-rustsbi = { version = "0.4.0" }
+rustsbi = "0.4.0"
 sbi-rt = "0.0.3"
 sbi-spec = { version = "0.0.8", features = [ "legacy" ] }
 spin = "0.9.8"

--- a/src/device/clint.rs
+++ b/src/device/clint.rs
@@ -4,23 +4,6 @@ use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
 use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
 use fdt::Fdt;
 
-mod register {
-    //! Ref: [https://chromitem-soc.readthedocs.io/en/latest/clint.html](https://chromitem-soc.readthedocs.io/en/latest/clint.html)
-    //!
-    //! | Register-Name | Offset(hex) | Size(Bits) | Reset(hex) | Description                                                        |
-    //! | ------------- | ----------- | ---------- | ---------- | -----------                                                        |
-    //! | msip          | 0x0         | 32         | 0x0        | This register generates machine mode software interrupts when set. |
-    //! | mtimecmp      | 0x4000      | 64         | 0x0        | This register holds the compare value for the timer.               |
-    //! | mtime         | 0xBFF8      | 64         | 0x0        | Provides the current timer value.                                  |
-
-    /// Offset of `MISP` register
-    pub const MSIP_OFFSET: usize = 0x0;
-    /// Offset of `MTIMECMP` register
-    pub const MTIMECMP_OFFSET: usize = 0x4000;
-    /// Offset of `MTIME` register
-    pub const MTIME_OFFSET: usize = 0xbff8;
-}
-
 #[allow(clippy::doc_markdown)]
 /// CLINT: Core Local INTerrupt
 /// Local interrupt controller

--- a/src/device/clint.rs
+++ b/src/device/clint.rs
@@ -1,9 +1,8 @@
 //! CLINT: *C*ore *L*ocal *Int*errupt
 
 use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
-use crate::memmap::{constant, GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
+use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
 use fdt::Fdt;
-use rustsbi::{HartMask, SbiRet};
 
 mod register {
     //! Ref: [https://chromitem-soc.readthedocs.io/en/latest/clint.html](https://chromitem-soc.readthedocs.io/en/latest/clint.html)
@@ -18,7 +17,6 @@ mod register {
     pub const MSIP_OFFSET: usize = 0x0;
     /// Offset of `MTIMECMP` register
     pub const MTIMECMP_OFFSET: usize = 0x4000;
-    #[allow(dead_code)]
     /// Offset of `MTIME` register
     pub const MTIME_OFFSET: usize = 0xbff8;
 }
@@ -64,35 +62,5 @@ impl MmioDevice for Clint {
             self.paddr()..self.paddr() + self.size(),
             &PTE_FLAGS_FOR_DEVICE,
         )
-    }
-}
-
-/// Ref: [https://github.com/rustsbi/rustsbi-qemu/blob/main/rustsbi-qemu/src/clint.rs](https://github.com/rustsbi/rustsbi-qemu/blob/main/rustsbi-qemu/src/clint.rs)
-impl rustsbi::Timer for Clint {
-    /// Programs the clock for the next event after `stime_value` time.
-    fn set_timer(&self, stime_value: u64) {
-        unsafe {
-            let hart_id = riscv::register::mhartid::read();
-            assert_eq!(hart_id, 0);
-            let mtimecmp_ptr = (self.base_addr.raw() + register::MTIMECMP_OFFSET) as *mut u64;
-            mtimecmp_ptr.write_volatile(stime_value);
-        }
-    }
-}
-
-impl rustsbi::Ipi for Clint {
-    /// Send an inter-processor interrupt to all the harts defined in `hart_mask`.
-    fn send_ipi(&self, hart_mask: HartMask) -> SbiRet {
-        for i in 0..constant::MAX_HART_NUM {
-            // TODO check hsm wheter allow_ipi enabled.
-            if hart_mask.has_bit(i) {
-                let msip_ptr = (self.base_addr.raw() + register::MSIP_OFFSET) as *mut u64;
-                unsafe {
-                    let msip_value = msip_ptr.read_volatile();
-                    msip_ptr.write_volatile(msip_value | i as u64);
-                }
-            }
-        }
-        SbiRet::success(0)
     }
 }


### PR DESCRIPTION
- Remove unused `RustSBI` impl.
- Remove the `clint::register`.

Fix #75 