### PR TITLE
Implement the identity_map feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ codegen-units = 1
 [features]
 # debug log
 debug_log = []
+# identity memory map
+identity_map = []
 
 [dependencies]
 elf = { version = "0.7.2", default-features = false }

--- a/memory.x
+++ b/memory.x
@@ -2,9 +2,9 @@ MEMORY
 {
   FLASH (rx) : ORIGIN = 0x83000000, LENGTH = 2M
   BOOT_RAM (rw) : ORIGIN = 0x83200000, LENGTH = 6M
-  RAM_HEAP (rwx) : ORIGIN = 0x84000000, LENGTH = 384M
-  RAM (rwx) : ORIGIN = 0x9c000000, LENGTH = 32M
-  L2_LIM (rw) : ORIGIN = 0x9e000000, LENGTH = 8M
+  RAM_HEAP (rwx) : ORIGIN = 0x84000000, LENGTH = 128M
+  RAM (rwx) : ORIGIN = 0x8c000000, LENGTH = 32M
+  L2_LIM (rw) : ORIGIN = 0x8e000000, LENGTH = 8M
 }
 
 /*
@@ -23,7 +23,7 @@ REGION_ALIAS("REGION_HEAP", RAM_HEAP);
 REGION_ALIAS("REGION_STACK", L2_LIM);
 
 _stack_start = ORIGIN(L2_LIM) + LENGTH(L2_LIM);
-_hv_heap_size = 0x18000000;
+_hv_heap_size = 0x8000000;
 _b_stack_size = 0x200000;
 
 /* defined section in hikami */

--- a/src/device.rs
+++ b/src/device.rs
@@ -271,7 +271,7 @@ impl Devices {
             device_mapping.push(initrd.memmap());
         }
 
-        // disable drive emulation
+        // disable drive emulation if `identity_map` feature is enabled
         if cfg!(feature = "identity_map") {
             if let Some(mmc) = &self.mmc {
                 device_mapping.push(mmc.memmap());

--- a/src/device.rs
+++ b/src/device.rs
@@ -271,6 +271,19 @@ impl Devices {
             device_mapping.push(initrd.memmap());
         }
 
+        // disable drive emulation
+        if cfg!(feature = "identity_map") {
+            if let Some(mmc) = &self.mmc {
+                device_mapping.push(mmc.memmap());
+            }
+            if let Some(pci) = &self.pci {
+                if let Some(sata) = &pci.pci_devices.sata {
+                    use pci::PciDevice;
+                    device_mapping.push(sata.memmap());
+                }
+            }
+        }
+
         device_mapping
     }
 }

--- a/src/device/pci.rs
+++ b/src/device/pci.rs
@@ -64,6 +64,9 @@ pub trait PciDevice {
     /// Initialize pci device.
     /// * `pci`: struct `Pci`
     fn init(&self, pci_config_space_base_addr: HostPhysicalAddress);
+
+    /// Return memory map between physical to physical (identity map) for crate page table.
+    fn memmap(&self) -> MemoryMap;
 }
 
 #[derive(Debug)]

--- a/src/device/pci/iommu.rs
+++ b/src/device/pci/iommu.rs
@@ -221,4 +221,8 @@ impl PciDevice for IoMmu {
         Self::init_page_table(ddt_addr);
         registers.ddtp.set(IoMmuMode::Lv1, ddt_addr);
     }
+
+    fn memmap(&self) -> MemoryMap {
+        unreachable!();
+    }
 }

--- a/src/device/pci/sata.rs
+++ b/src/device/pci/sata.rs
@@ -444,4 +444,12 @@ impl PciDevice for Sata {
     fn init(&self, _: HostPhysicalAddress) {
         unreachable!();
     }
+
+    fn memmap(&self) -> MemoryMap {
+        MemoryMap::new(
+            GuestPhysicalAddress(self.abar.start.raw())..GuestPhysicalAddress(self.abar.end.raw()),
+            self.abar.clone(),
+            &super::PTE_FLAGS_FOR_DEVICE,
+        )
+    }
 }

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -238,9 +238,16 @@ impl Guest {
 
         if !GUEST_INITRD.is_empty() {
             let aligned_initrd_size = GUEST_INITRD.len().div_ceil(PAGE_SIZE) * PAGE_SIZE;
-            let initrd_start = guest_memory::DRAM_BASE
-                + guest_memory::DRAM_SIZE_PER_GUEST * (self.hart_id + 1)
-                - aligned_initrd_size;
+            let guest_base =
+                guest_memory::DRAM_BASE + guest_memory::DRAM_SIZE_PER_GUEST * (self.hart_id + 1);
+            let initrd_start = guest_base + guest_memory::DRAM_SIZE_PER_GUEST - aligned_initrd_size;
+
+            crate::println!(
+                "initrd (GPA): {:#x}..{:#x}",
+                initrd_start.raw(),
+                initrd_start.raw() + GUEST_INITRD.len()
+            );
+
             unsafe {
                 core::ptr::copy(
                     GUEST_INITRD.as_ptr(),

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -149,9 +149,11 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
     let (guest_entry_point, elf_end_addr) =
         new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr());
 
-    // allocate page tables to all remain guest memory region
-    let guest_memory_end = new_guest.memory_region().end;
-    new_guest.allocate_memory_region(elf_end_addr..guest_memory_end);
+    if !cfg!(feature = "identity_map") {
+        // allocate page tables to all remain guest memory region
+        let guest_memory_end = new_guest.memory_region().end;
+        new_guest.allocate_memory_region(elf_end_addr..guest_memory_end);
+    }
 
     // set device memory map
     hypervisor_data

--- a/src/memmap/page_table.rs
+++ b/src/memmap/page_table.rs
@@ -105,6 +105,7 @@ impl PageTableEntry {
     }
 
     /// Is pte invalid?
+    #[allow(clippy::no_effect_underscore_binding)]
     fn is_invalid(self) -> bool {
         let pte_v = self.0 & 0x1;
         let _pte_r = (self.0 >> 1) & 0x1;


### PR DESCRIPTION
Implement the identity_map feature.
This feature is intended to use on device which does not support IOMMU device.