### PR TITLE
Fix SATA emulation bug

### DIFF
--- a/guest_image/guest.dts
+++ b/guest_image/guest.dts
@@ -89,7 +89,7 @@
 	};
 
 	chosen {
-		bootargs = "root=/dev/vda locale.LANG=en_US.UTF-8";
+		bootargs = "root=/dev/sda locale.LANG=en_US.UTF-8";
 		stdout-path = "/soc/serial@10000000";
 		rng-seed = <0x9775b34d 0xe39158f2 0x3e9d10b1 0x73692dfd 0x13c15814 0xa4ad203f 0x8b0d62f7 0x6bf8a79d>;
 	};

--- a/hikami_core/src/device.rs
+++ b/hikami_core/src/device.rs
@@ -271,10 +271,6 @@ impl Devices {
             self.clint.memmap(),
         ]);
 
-        if let Some(pci) = &self.pci {
-            device_mapping.push(pci.memmap());
-            device_mapping.extend_from_slice(pci.pci_memory_maps());
-        }
         if let Some(rtc) = &self.rtc {
             device_mapping.push(rtc.memmap());
         }
@@ -282,16 +278,23 @@ impl Devices {
             device_mapping.push(initrd.memmap());
         }
 
-        // disable drive emulation if `identity_map` feature is enabled
-        if cfg!(feature = "identity_map") {
-            if let Some(mmc) = &self.mmc {
-                device_mapping.push(mmc.memmap());
-            }
-            if let Some(pci) = &self.pci {
+        if let Some(pci) = &self.pci {
+            device_mapping.push(pci.memmap());
+
+            // mapping whole region of block divices
+            if cfg!(feature = "identity_map") {
+                device_mapping.extend_from_slice(pci.pci_memory_maps());
+            } else {
+                // mapping pass-through registers' region
                 if let Some(sata) = &pci.pci_devices.sata {
                     use pci::PciDevice;
                     device_mapping.push(sata.memmap());
                 }
+            }
+        }
+        if cfg!(feature = "identity_map") {
+            if let Some(mmc) = &self.mmc {
+                device_mapping.push(mmc.memmap());
             }
         }
 

--- a/hikami_core/src/device.rs
+++ b/hikami_core/src/device.rs
@@ -281,15 +281,9 @@ impl Devices {
         if let Some(pci) = &self.pci {
             device_mapping.push(pci.memmap());
 
-            // mapping whole region of block divices
             if cfg!(feature = "identity_map") {
+                // mapping whole memory mapped register region of block divices.
                 device_mapping.extend_from_slice(pci.pci_memory_maps());
-            } else {
-                // mapping pass-through registers' region
-                if let Some(sata) = &pci.pci_devices.sata {
-                    use pci::PciDevice;
-                    device_mapping.push(sata.memmap());
-                }
             }
         }
         if cfg!(feature = "identity_map") {

--- a/hikami_core/src/device/pci.rs
+++ b/hikami_core/src/device/pci.rs
@@ -8,7 +8,7 @@ pub mod config_register;
 
 use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
 use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
-use config_register::{read_config_register, ConfigSpaceHeaderField};
+use config_register::{ConfigSpaceHeaderField, read_config_register};
 
 use alloc::vec::Vec;
 use core::ops::Range;
@@ -298,7 +298,7 @@ impl MmioDevice for Pci {
         let pci_addr_space = PciAddressSpace::new(device_tree, compatibles);
         let pci_devices = PciDevices::new(device_tree, base_address, &pci_addr_space);
 
-        // 32 bit memory map
+        // 32 bit reserved memory map
         memory_maps.push(MemoryMap::new(
             GuestPhysicalAddress(pci_addr_space.bit32_memory_space.start.raw())
                 ..GuestPhysicalAddress(pci_addr_space.bit32_memory_space.end.raw()),
@@ -306,7 +306,7 @@ impl MmioDevice for Pci {
             &PTE_FLAGS_FOR_DEVICE,
         ));
 
-        // 64 bit memory map
+        // 64 bit reserved memory map
         memory_maps.push(MemoryMap::new(
             GuestPhysicalAddress(pci_addr_space.bit64_memory_space.start.raw())
                 ..GuestPhysicalAddress(pci_addr_space.bit64_memory_space.end.raw()),
@@ -331,6 +331,7 @@ impl MmioDevice for Pci {
         self.base_addr
     }
 
+    /// mapping sata register region.
     fn memmap(&self) -> MemoryMap {
         let vaddr = GuestPhysicalAddress(self.paddr().raw());
         MemoryMap::new(

--- a/hikami_core/src/device/pci.rs
+++ b/hikami_core/src/device/pci.rs
@@ -8,7 +8,7 @@ pub mod config_register;
 
 use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
 use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
-use config_register::{ConfigSpaceHeaderField, read_config_register};
+use config_register::{read_config_register, ConfigSpaceHeaderField};
 
 use alloc::vec::Vec;
 use core::ops::Range;
@@ -60,7 +60,6 @@ pub trait PciDevice {
         device_id: u32,
         pci_config_space_base_addr: HostPhysicalAddress,
         pci_addr_space: &PciAddressSpace,
-        memory_maps: &mut Vec<MemoryMap>,
     ) -> Self;
 
     /// Initialize pci device.
@@ -87,7 +86,6 @@ impl PciDevices {
         device_tree: &Fdt,
         pci_config_space_base_addr: HostPhysicalAddress,
         pci_addr_space: &PciAddressSpace,
-        memory_maps: &mut Vec<MemoryMap>,
     ) -> Self {
         /// Max PCI bus size.
         const PCI_MAX_BUS: u8 = 255;
@@ -143,7 +141,6 @@ impl PciDevices {
                             device_id.into(),
                             pci_config_space_base_addr,
                             pci_addr_space,
-                            memory_maps,
                         ));
                     }
 
@@ -299,8 +296,7 @@ impl MmioDevice for Pci {
         let mut memory_maps = Vec::new();
         let base_address = HostPhysicalAddress(region.starting_address as usize);
         let pci_addr_space = PciAddressSpace::new(device_tree, compatibles);
-        let pci_devices =
-            PciDevices::new(device_tree, base_address, &pci_addr_space, &mut memory_maps);
+        let pci_devices = PciDevices::new(device_tree, base_address, &pci_addr_space);
 
         // 32 bit memory map
         memory_maps.push(MemoryMap::new(

--- a/hikami_core/src/device/pci/iommu.rs
+++ b/hikami_core/src/device/pci/iommu.rs
@@ -4,15 +4,14 @@
 mod register_map;
 
 use super::config_register::{
-    ConfigSpaceHeaderField, get_bar_size, read_config_register, write_config_register,
+    get_bar_size, read_config_register, write_config_register, ConfigSpaceHeaderField,
 };
 use super::{Bdf, PciAddressSpace, PciDevice};
-use crate::PageBlock;
 use crate::h_extension::csrs::hgatp;
-use crate::memmap::{HostPhysicalAddress, MemoryMap, page_table::constants::PAGE_SIZE};
+use crate::memmap::{page_table::constants::PAGE_SIZE, HostPhysicalAddress, MemoryMap};
+use crate::PageBlock;
 use register_map::{IoMmuMode, IoMmuRegisters};
 
-use alloc::vec::Vec;
 use core::ops::Range;
 use fdt::Fdt;
 
@@ -137,7 +136,6 @@ impl PciDevice for IoMmu {
         _device_id: u32,
         _pci_config_space_base_addr: HostPhysicalAddress,
         _pci_addr_space: &PciAddressSpace,
-        _memory_maps: &mut Vec<MemoryMap>,
     ) -> Self {
         unreachable!("use `IoMmu::new_from_dtb` instead.");
     }

--- a/hikami_core/src/device/pci/iommu.rs
+++ b/hikami_core/src/device/pci/iommu.rs
@@ -4,12 +4,12 @@
 mod register_map;
 
 use super::config_register::{
-    get_bar_size, read_config_register, write_config_register, ConfigSpaceHeaderField,
+    ConfigSpaceHeaderField, get_bar_size, read_config_register, write_config_register,
 };
 use super::{Bdf, PciAddressSpace, PciDevice};
-use crate::h_extension::csrs::hgatp;
-use crate::memmap::{page_table::constants::PAGE_SIZE, HostPhysicalAddress, MemoryMap};
 use crate::PageBlock;
+use crate::h_extension::csrs::hgatp;
+use crate::memmap::{HostPhysicalAddress, MemoryMap, page_table::constants::PAGE_SIZE};
 use register_map::{IoMmuMode, IoMmuRegisters};
 
 use core::ops::Range;

--- a/hikami_core/src/device/pci/sata.rs
+++ b/hikami_core/src/device/pci/sata.rs
@@ -4,18 +4,17 @@
 
 mod command;
 
-use super::config_register::{ConfigSpaceHeaderField, get_bar_size, read_config_register};
+use super::config_register::{get_bar_size, read_config_register, ConfigSpaceHeaderField};
 use super::{Bdf, PciAddressSpace, PciDevice};
 use crate::device::DeviceEmulateError;
 use crate::memmap::page_table::g_stage_trans_addr;
 use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
 use command::{
-    COMMAND_HEADER_SIZE, CommandHeader, CommandTable, CommandTableGpaStorage, TransferDirection,
+    CommandHeader, CommandTable, CommandTableGpaStorage, TransferDirection, COMMAND_HEADER_SIZE,
 };
 
 use alloc::boxed::Box;
 use alloc::vec;
-use alloc::vec::Vec;
 use core::ops::Range;
 
 /// Number of SATA port.
@@ -406,7 +405,6 @@ impl PciDevice for Sata {
         device_id: u32,
         pci_config_space_base_addr: HostPhysicalAddress,
         pci_addr_space: &PciAddressSpace,
-        _memory_maps: &mut Vec<MemoryMap>,
     ) -> Self {
         let config_space_header_addr =
             pci_config_space_base_addr.0 | bdf.calc_config_space_header_offset();

--- a/hikami_core/src/device/pci/sata.rs
+++ b/hikami_core/src/device/pci/sata.rs
@@ -4,13 +4,13 @@
 
 mod command;
 
-use super::config_register::{get_bar_size, read_config_register, ConfigSpaceHeaderField};
+use super::config_register::{ConfigSpaceHeaderField, get_bar_size, read_config_register};
 use super::{Bdf, PciAddressSpace, PciDevice};
 use crate::device::DeviceEmulateError;
 use crate::memmap::page_table::g_stage_trans_addr;
 use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
 use command::{
-    CommandHeader, CommandTable, CommandTableGpaStorage, TransferDirection, COMMAND_HEADER_SIZE,
+    COMMAND_HEADER_SIZE, CommandHeader, CommandTable, CommandTableGpaStorage, TransferDirection,
 };
 
 use alloc::boxed::Box;

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -75,7 +75,7 @@ impl Guest {
     fn map_guest_dtb(
         _hart_id: usize,
         page_table_addr: HostPhysicalAddress,
-        guest_dtb: &'static [u8; include_bytes!("../guest_image/guest.dtb").len()],
+        guest_dtb: &'static [u8],
     ) -> GuestPhysicalAddress {
         use PteFlag::{Accessed, Dirty, Read, User, Valid, Write};
 


### PR DESCRIPTION
Corrected the SATA device's memory mapping by mapping PCI device's memory-mapped register region only when `identity_map` feature is enabled.