### PR TITLE
Change `MmioDevice` trait to support multiple regs in device tree

### DIFF
--- a/hikami_core/src/device.rs
+++ b/hikami_core/src/device.rs
@@ -188,10 +188,6 @@ pub trait MmioDevice {
     fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self>
     where
         Self: Sized;
-    /// Return size of memory region.
-    fn size(&self) -> usize;
-    /// Return address of physical memory
-    fn paddr(&self) -> HostPhysicalAddress;
     /// Return memory map between physical to physical (identity map) for crate page table.
     fn memmap(&self) -> MemoryMap;
 }

--- a/hikami_core/src/device.rs
+++ b/hikami_core/src/device.rs
@@ -188,8 +188,8 @@ pub trait MmioDevice {
     fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self>
     where
         Self: Sized;
-    /// Return memory map between physical to physical (identity map) for crate page table.
-    fn memmap(&self) -> MemoryMap;
+    /// Return memory maps between physical to physical (identity map) for crate page table.
+    fn memmap(&self) -> Vec<MemoryMap>;
 }
 
 /// Manage devices sush as uart, plic, etc...
@@ -261,24 +261,22 @@ impl Devices {
         let mut device_mapping: Vec<MemoryMap> = self
             .virtio_list
             .iter()
-            .flat_map(|virt| [virt.memmap()])
+            .flat_map(|virt| virt.memmap())
             .collect();
 
-        device_mapping.extend_from_slice(&[
-            self.uart.memmap(),
-            self.plic.memmap(),
-            self.clint.memmap(),
-        ]);
+        device_mapping.extend_from_slice(&self.uart.memmap());
+        device_mapping.extend_from_slice(&self.plic.memmap());
+        device_mapping.extend_from_slice(&self.clint.memmap());
 
         if let Some(rtc) = &self.rtc {
-            device_mapping.push(rtc.memmap());
+            device_mapping.extend_from_slice(&rtc.memmap());
         }
         if let Some(initrd) = &self.initrd {
-            device_mapping.push(initrd.memmap());
+            device_mapping.extend_from_slice(&initrd.memmap());
         }
 
         if let Some(pci) = &self.pci {
-            device_mapping.push(pci.memmap());
+            device_mapping.extend_from_slice(&pci.memmap());
 
             if cfg!(feature = "identity_map") {
                 // mapping whole memory mapped register region of block divices.
@@ -287,7 +285,7 @@ impl Devices {
         }
         if cfg!(feature = "identity_map") {
             if let Some(mmc) = &self.mmc {
-                device_mapping.push(mmc.memmap());
+                device_mapping.extend_from_slice(&mmc.memmap());
             }
         }
 

--- a/hikami_core/src/device/axi_sdc.rs
+++ b/hikami_core/src/device/axi_sdc.rs
@@ -132,14 +132,6 @@ impl MmioDevice for Mmc {
         })
     }
 
-    fn size(&self) -> usize {
-        self.size
-    }
-
-    fn paddr(&self) -> HostPhysicalAddress {
-        self.base_addr
-    }
-
     fn memmap(&self) -> MemoryMap {
         let vaddr = GuestPhysicalAddress(self.paddr().raw());
         MemoryMap::new(

--- a/hikami_core/src/device/axi_sdc.rs
+++ b/hikami_core/src/device/axi_sdc.rs
@@ -27,6 +27,13 @@ pub struct Mmc {
     is_transferring: bool,
 }
 
+impl Mmc {
+    /// Return base address of memory mapped register region.
+    fn base_addr(&self) -> HostPhysicalAddress {
+        HostPhysicalAddress(self.register_map_region.starting_address as usize)
+    }
+}
+
 impl EmulateDevice for Mmc {
     /// Emulate loading port registers.
     #[allow(clippy::cast_possible_truncation)]
@@ -41,14 +48,14 @@ impl EmulateDevice for Mmc {
         dst_addr: HostPhysicalAddress,
         value: u32,
     ) -> Result<(), DeviceEmulateError> {
-        let offset = dst_addr.raw() - self.base_addr.raw();
+        let offset = dst_addr.raw() - self.base_addr().raw();
         match offset {
             // Argument
             //
             // Start transfer when write command to `Argument`
             // See: https://github.com/eugene-tarassov/vivado-risc-v/blob/d72a439f786b455cc321e2e615d7954a75f9ebde/sdc/axi_sdc_controller.v#L392
             0 => {
-                let registers_ptr = self.base_addr.raw() as *mut SdcRegisters;
+                let registers_ptr = self.base_addr().raw() as *mut SdcRegisters;
                 let command = unsafe { ((*registers_ptr).command) as usize };
                 let dma_gpa = GuestPhysicalAddress(unsafe { (*registers_ptr).dma_addres } as usize);
 
@@ -86,7 +93,7 @@ impl EmulateDevice for Mmc {
             60 => {
                 // end transfer
                 if value == 0 && self.is_transferring {
-                    let registers_ptr = self.base_addr.raw() as *mut SdcRegisters;
+                    let registers_ptr = self.base_addr().raw() as *mut SdcRegisters;
                     // restore address
                     unsafe {
                         (*registers_ptr).dma_addres = self.dma_addr.raw() as u64;

--- a/hikami_core/src/device/axi_sdc.rs
+++ b/hikami_core/src/device/axi_sdc.rs
@@ -4,21 +4,21 @@
 
 mod register;
 
-use super::{DeviceEmulateError, DmaHostBuffer, EmulateDevice, MmioDevice, PTE_FLAGS_FOR_DEVICE};
+use super::{DeviceEmulateError, DmaHostBuffer, EmulateDevice, MmioDevice};
 use crate::memmap::page_table::{constants::PAGE_SIZE, g_stage_trans_addr};
 use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
 use register::SdcRegisters;
 
-use fdt::Fdt;
+use alloc::vec;
+use alloc::vec::Vec;
+use fdt::{Fdt, standard_nodes::MemoryRegion};
 
 #[allow(clippy::doc_markdown)]
 /// MMC: Multi Media Card
 #[derive(Debug)]
 pub struct Mmc {
-    /// Base address of memory map.
-    base_addr: HostPhysicalAddress,
-    /// Memory map size.
-    size: usize,
+    /// Memory map for memory mapped register.
+    register_map_region: MemoryRegion,
     /// DMA address.
     dma_addr: GuestPhysicalAddress,
     /// DMA alternative buffer
@@ -117,27 +117,22 @@ impl EmulateDevice for Mmc {
 
 impl MmioDevice for Mmc {
     fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let region = device_tree
+        let register_map_region = device_tree
             .find_compatible(compatibles)?
             .reg()
             .unwrap()
-            .next()?;
+            .next()
+            .unwrap();
 
         Some(Mmc {
-            base_addr: HostPhysicalAddress(region.starting_address as usize),
-            size: region.size.unwrap(),
+            register_map_region,
             dma_addr: GuestPhysicalAddress(0),
             dma_alt_buffer: DmaHostBuffer::new(PAGE_SIZE),
             is_transferring: false,
         })
     }
 
-    fn memmap(&self) -> MemoryMap {
-        let vaddr = GuestPhysicalAddress(self.paddr().raw());
-        MemoryMap::new(
-            vaddr..vaddr + self.size(),
-            self.paddr()..self.paddr() + self.size(),
-            &PTE_FLAGS_FOR_DEVICE,
-        )
+    fn memmap(&self) -> Vec<MemoryMap> {
+        vec![MemoryMap::from(self.register_map_region)]
     }
 }

--- a/hikami_core/src/device/clint.rs
+++ b/hikami_core/src/device/clint.rs
@@ -1,41 +1,38 @@
 //! CLINT: *C*ore *L*ocal *Int*errupt
 
-use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
-use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
-use fdt::Fdt;
+use super::MmioDevice;
+use crate::memmap::MemoryMap;
+
+use alloc::vec::Vec;
+use fdt::{Fdt, standard_nodes::MemoryRegion};
 
 #[allow(clippy::doc_markdown)]
 /// CLINT: Core Local INTerrupt
 /// Local interrupt controller
 #[derive(Debug)]
 pub struct Clint {
-    /// Base address of memory map.
-    base_addr: HostPhysicalAddress,
-    /// Memory map size.
-    size: usize,
+    /// Memory maps for memory mapped register.
+    register_map_regions: Vec<MemoryRegion>,
 }
 
 impl MmioDevice for Clint {
     fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let region = device_tree
+        let register_map_regions: Vec<MemoryRegion> = device_tree
             .find_compatible(compatibles)?
             .reg()
             .unwrap()
-            .next()
-            .unwrap();
+            .collect();
 
         Some(Clint {
-            base_addr: HostPhysicalAddress(region.starting_address as usize),
-            size: region.size.unwrap(),
+            register_map_regions,
         })
     }
 
-    fn memmap(&self) -> MemoryMap {
-        let vaddr = GuestPhysicalAddress(self.paddr().raw());
-        MemoryMap::new(
-            vaddr..vaddr + self.size(),
-            self.paddr()..self.paddr() + self.size(),
-            &PTE_FLAGS_FOR_DEVICE,
-        )
+    fn memmap(&self) -> Vec<MemoryMap> {
+        self.register_map_regions
+            .clone()
+            .into_iter()
+            .map(|region| MemoryMap::from(region))
+            .collect()
     }
 }

--- a/hikami_core/src/device/clint.rs
+++ b/hikami_core/src/device/clint.rs
@@ -30,14 +30,6 @@ impl MmioDevice for Clint {
         })
     }
 
-    fn size(&self) -> usize {
-        self.size
-    }
-
-    fn paddr(&self) -> HostPhysicalAddress {
-        self.base_addr
-    }
-
     fn memmap(&self) -> MemoryMap {
         let vaddr = GuestPhysicalAddress(self.paddr().raw());
         MemoryMap::new(

--- a/hikami_core/src/device/clint.rs
+++ b/hikami_core/src/device/clint.rs
@@ -1,7 +1,9 @@
 //! CLINT: *C*ore *L*ocal *Int*errupt
 
-use super::MmioDevice;
-use crate::memmap::MemoryMap;
+use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
+use crate::memmap::{
+    GuestPhysicalAddress, HostPhysicalAddress, MemoryMap, page_table::constants::PAGE_SIZE,
+};
 
 use alloc::vec::Vec;
 use fdt::{Fdt, standard_nodes::MemoryRegion};
@@ -32,7 +34,24 @@ impl MmioDevice for Clint {
         self.register_map_regions
             .clone()
             .into_iter()
-            .map(|region| MemoryMap::from(region))
+            .map(|region| {
+                let mut size = region.size.unwrap();
+                let mut virt_start = GuestPhysicalAddress(region.starting_address as usize);
+                let mut phys_start = HostPhysicalAddress(region.starting_address as usize);
+
+                // change memory map region if region size is less than the page size.
+                if phys_start % PAGE_SIZE != 0 && size < PAGE_SIZE {
+                    size = PAGE_SIZE;
+                    virt_start = virt_start - (virt_start % PAGE_SIZE);
+                    phys_start = phys_start - (phys_start % PAGE_SIZE);
+                }
+
+                MemoryMap::new(
+                    virt_start..virt_start + size,
+                    phys_start..phys_start + size,
+                    &PTE_FLAGS_FOR_DEVICE,
+                )
+            })
             .collect()
     }
 }

--- a/hikami_core/src/device/initrd.rs
+++ b/hikami_core/src/device/initrd.rs
@@ -46,14 +46,6 @@ impl MmioDevice for Initrd {
         unreachable!("use Initrd::try_new_from_node_path instead")
     }
 
-    fn size(&self) -> usize {
-        self.size
-    }
-
-    fn paddr(&self) -> HostPhysicalAddress {
-        self.base_addr
-    }
-
     fn memmap(&self) -> MemoryMap {
         let vaddr = GuestPhysicalAddress(self.paddr().raw());
         MemoryMap::new(

--- a/hikami_core/src/device/initrd.rs
+++ b/hikami_core/src/device/initrd.rs
@@ -1,18 +1,19 @@
 //! initrd: INITial RamDisk
 #![allow(clippy::doc_markdown)]
 
-use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
-use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
-use fdt::Fdt;
+use super::MmioDevice;
+use crate::memmap::MemoryMap;
+
+use alloc::vec;
+use alloc::vec::Vec;
+use fdt::{Fdt, standard_nodes::MemoryRegion};
 
 /// A scheme for loading a temporary root file system into memory,
 /// to be used as part of the Linux startup process.
 #[derive(Debug)]
 pub struct Initrd {
-    /// Base address of memory map.
-    base_addr: HostPhysicalAddress,
-    /// Memory map size.
-    size: usize,
+    /// Memory maps
+    memory_map: MemoryRegion,
 }
 
 impl Initrd {
@@ -32,8 +33,10 @@ impl Initrd {
                 let end = u32::from_be_bytes(end[4..].try_into().unwrap()) as usize;
 
                 Some(Initrd {
-                    base_addr: HostPhysicalAddress(start),
-                    size: end - start,
+                    memory_map: MemoryRegion {
+                        starting_address: start as *const u8,
+                        size: Some(end - start),
+                    },
                 })
             }
             None => None,
@@ -46,12 +49,7 @@ impl MmioDevice for Initrd {
         unreachable!("use Initrd::try_new_from_node_path instead")
     }
 
-    fn memmap(&self) -> MemoryMap {
-        let vaddr = GuestPhysicalAddress(self.paddr().raw());
-        MemoryMap::new(
-            vaddr..vaddr + self.size(),
-            self.paddr()..self.paddr() + self.size(),
-            &PTE_FLAGS_FOR_DEVICE,
-        )
+    fn memmap(&self) -> Vec<MemoryMap> {
+        vec![MemoryMap::from(self.memory_map)]
     }
 }

--- a/hikami_core/src/device/pci.rs
+++ b/hikami_core/src/device/pci.rs
@@ -323,14 +323,6 @@ impl MmioDevice for Pci {
         })
     }
 
-    fn size(&self) -> usize {
-        self.size
-    }
-
-    fn paddr(&self) -> HostPhysicalAddress {
-        self.base_addr
-    }
-
     /// mapping sata register region.
     fn memmap(&self) -> MemoryMap {
         let vaddr = GuestPhysicalAddress(self.paddr().raw());

--- a/hikami_core/src/device/pci.rs
+++ b/hikami_core/src/device/pci.rs
@@ -328,7 +328,7 @@ impl MmioDevice for Pci {
         self.register_map_regions
             .clone()
             .into_iter()
-            .map(|region| MemoryMap::from(region))
+            .map(MemoryMap::from)
             .collect()
     }
 }

--- a/hikami_core/src/device/pci.rs
+++ b/hikami_core/src/device/pci.rs
@@ -12,7 +12,7 @@ use config_register::{ConfigSpaceHeaderField, read_config_register};
 
 use alloc::vec::Vec;
 use core::ops::Range;
-use fdt::Fdt;
+use fdt::{Fdt, standard_nodes::MemoryRegion};
 
 /// Bus - Device - Function
 #[derive(Debug)]
@@ -256,7 +256,7 @@ impl PciAddressSpace {
 #[allow(clippy::struct_field_names)]
 pub struct Pci {
     /// Memory maps for pci register.
-    register_maps: Vec<MemoryMap>,
+    register_map_regions: Vec<MemoryRegion>,
     /// PCI address space manager
     _pci_addr_space: PciAddressSpace,
     /// Memory maps for pci devices
@@ -277,31 +277,23 @@ impl Pci {
     /// Initialize PCI devices.
     pub fn init_pci_devices(&self) {
         if let Some(iommu) = &self.pci_devices.iommu {
-            iommu.init(self.register_maps[0].phys.start);
+            iommu.init(HostPhysicalAddress(
+                self.register_map_regions[0].starting_address as usize,
+            ));
         }
     }
 }
 
 impl MmioDevice for Pci {
     fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let register_maps: Vec<MemoryMap> = device_tree
+        let register_map_regions: Vec<MemoryRegion> = device_tree
             .find_compatible(compatibles)?
             .reg()
             .unwrap()
-            .map(|region| {
-                let size = region.size.unwrap();
-                let virt_start = GuestPhysicalAddress(region.starting_address as usize);
-                let phys_start = HostPhysicalAddress(region.starting_address as usize);
-                MemoryMap::new(
-                    virt_start..virt_start + size,
-                    phys_start..phys_start + size,
-                    &PTE_FLAGS_FOR_DEVICE,
-                )
-            })
             .collect();
 
         // assume that pci register contains first region.
-        let base_address = register_maps[0].phys.start;
+        let base_address = HostPhysicalAddress(register_map_regions[0].starting_address as usize);
 
         let mut memory_maps = Vec::new();
         let pci_addr_space = PciAddressSpace::new(device_tree, compatibles);
@@ -324,7 +316,7 @@ impl MmioDevice for Pci {
         ));
 
         Some(Pci {
-            register_maps,
+            register_map_regions,
             _pci_addr_space: pci_addr_space,
             memory_maps,
             pci_devices,
@@ -332,7 +324,11 @@ impl MmioDevice for Pci {
     }
 
     /// mapping sata register region.
-    fn memmap(&self) -> &[MemoryMap] {
-        &self.register_maps
+    fn memmap(&self) -> Vec<MemoryMap> {
+        self.register_map_regions
+            .clone()
+            .into_iter()
+            .map(|region| MemoryMap::from(region))
+            .collect()
     }
 }

--- a/hikami_core/src/device/pci.rs
+++ b/hikami_core/src/device/pci.rs
@@ -255,10 +255,8 @@ impl PciAddressSpace {
 #[derive(Debug)]
 #[allow(clippy::struct_field_names)]
 pub struct Pci {
-    /// Base address of memory map.
-    base_addr: HostPhysicalAddress,
-    /// Memory map size.
-    size: usize,
+    /// Memory maps for pci register.
+    register_maps: Vec<MemoryMap>,
     /// PCI address space manager
     _pci_addr_space: PciAddressSpace,
     /// Memory maps for pci devices
@@ -279,22 +277,33 @@ impl Pci {
     /// Initialize PCI devices.
     pub fn init_pci_devices(&self) {
         if let Some(iommu) = &self.pci_devices.iommu {
-            iommu.init(self.base_addr);
+            iommu.init(self.register_maps[0].phys.start);
         }
     }
 }
 
 impl MmioDevice for Pci {
     fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let region = device_tree
+        let register_maps: Vec<MemoryMap> = device_tree
             .find_compatible(compatibles)?
             .reg()
             .unwrap()
-            .next()
-            .unwrap();
+            .map(|region| {
+                let size = region.size.unwrap();
+                let virt_start = GuestPhysicalAddress(region.starting_address as usize);
+                let phys_start = HostPhysicalAddress(region.starting_address as usize);
+                MemoryMap::new(
+                    virt_start..virt_start + size,
+                    phys_start..phys_start + size,
+                    &PTE_FLAGS_FOR_DEVICE,
+                )
+            })
+            .collect();
+
+        // assume that pci register contains first region.
+        let base_address = register_maps[0].phys.start;
 
         let mut memory_maps = Vec::new();
-        let base_address = HostPhysicalAddress(region.starting_address as usize);
         let pci_addr_space = PciAddressSpace::new(device_tree, compatibles);
         let pci_devices = PciDevices::new(device_tree, base_address, &pci_addr_space);
 
@@ -315,8 +324,7 @@ impl MmioDevice for Pci {
         ));
 
         Some(Pci {
-            base_addr: HostPhysicalAddress(region.starting_address as usize),
-            size: region.size.unwrap(),
+            register_maps,
             _pci_addr_space: pci_addr_space,
             memory_maps,
             pci_devices,
@@ -324,12 +332,7 @@ impl MmioDevice for Pci {
     }
 
     /// mapping sata register region.
-    fn memmap(&self) -> MemoryMap {
-        let vaddr = GuestPhysicalAddress(self.paddr().raw());
-        MemoryMap::new(
-            vaddr..vaddr + self.size(),
-            self.paddr()..self.paddr() + self.size(),
-            &PTE_FLAGS_FOR_DEVICE,
-        )
+    fn memmap(&self) -> &[MemoryMap] {
+        &self.register_maps
     }
 }

--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -1,12 +1,13 @@
 //! PLIC: Platform-Level Interrupt Controller  
 //! ref: [https://github.com/riscv/riscv-plic-spec/releases/download/1.0.0/riscv-plic-1.0.0.pdf](https://github.com/riscv/riscv-plic-spec/releases/download/1.0.0/riscv-plic-1.0.0.pdf)
 
-use super::{DeviceEmulateError, MmioDevice, PTE_FLAGS_FOR_DEVICE};
+use super::{DeviceEmulateError, MmioDevice};
 use crate::h_extension::csrs::{VsInterruptKind, hvip};
 use crate::memmap::constant::MAX_HART_NUM;
-use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
+use crate::memmap::{HostPhysicalAddress, MemoryMap};
 
-use fdt::Fdt;
+use alloc::vec::Vec;
+use fdt::{Fdt, standard_nodes::MemoryRegion};
 use riscv::register::sie;
 
 /// Max number of PLIC context.
@@ -44,10 +45,8 @@ impl ContextId {
 /// Interrupt controller for global interrupts.
 #[derive(Debug)]
 pub struct Plic {
-    /// Base address of memory map.
-    base_addr: HostPhysicalAddress,
-    /// Memory map size.
-    size: usize,
+    /// Memory maps for memory mapped register.
+    register_map_regions: Vec<MemoryRegion>,
     /// Claim complete flags for external interrupts emulation.
     ///
     /// Each bit indicates whether interrupts are claimed in context.
@@ -167,28 +166,23 @@ impl Plic {
 impl MmioDevice for Plic {
     #[allow(clippy::cast_ptr_alignment)]
     fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let region = device_tree
+        let register_map_regions: Vec<MemoryRegion> = device_tree
             .find_compatible(compatibles)?
             .reg()
             .unwrap()
-            .next()
-            .unwrap();
+            .collect();
 
         Some(Plic {
-            base_addr: HostPhysicalAddress(region.starting_address as usize),
-            size: region.size.unwrap(),
+            register_map_regions,
             claim_complete: [0u32; MAX_CONTEXT_NUM],
         })
     }
 
-    fn memmap(&self) -> MemoryMap {
-        // Pass through 0x0 - 0x20_0000.
-        // Disallow 0x20_0000 - for emulation.
-        let vaddr = GuestPhysicalAddress(self.paddr().raw());
-        MemoryMap::new(
-            vaddr..vaddr + CONTEXT_BASE,
-            self.paddr()..self.paddr() + CONTEXT_BASE,
-            &PTE_FLAGS_FOR_DEVICE,
-        )
+    fn memmap(&self) -> Vec<MemoryMap> {
+        self.register_map_regions
+            .clone()
+            .into_iter()
+            .map(|region| MemoryMap::from(region))
+            .collect()
     }
 }

--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -181,14 +181,6 @@ impl MmioDevice for Plic {
         })
     }
 
-    fn size(&self) -> usize {
-        self.size
-    }
-
-    fn paddr(&self) -> HostPhysicalAddress {
-        self.base_addr
-    }
-
     fn memmap(&self) -> MemoryMap {
         // Pass through 0x0 - 0x20_0000.
         // Disallow 0x20_0000 - for emulation.

--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -54,10 +54,24 @@ pub struct Plic {
 }
 
 impl Plic {
+    /// Return base address.
+    /// This function assumes that memory mapped register region is first one.
+    fn base_addr(&self) -> HostPhysicalAddress {
+        HostPhysicalAddress(self.register_map_regions[0].starting_address as usize)
+    }
+
+    /// Return first region size
+    /// This function assumes that memory mapped register region is first one.
+    fn size(&self) -> usize {
+        self.register_map_regions[0]
+            .size
+            .expect("no size plic memory-mapped register region")
+    }
+
     /// Read plic claim/update register and reflect to `claim_complete`.
     pub fn update_claim_complete(&mut self, context_id: &ContextId) {
         let claim_complete_addr =
-            self.base_addr + CONTEXT_BASE + CONTEXT_REGS_SIZE * context_id.raw() + CONTEXT_CLAIM;
+            self.base_addr() + CONTEXT_BASE + CONTEXT_REGS_SIZE * context_id.raw() + CONTEXT_CLAIM;
         let irq = unsafe { core::ptr::read_volatile(claim_complete_addr.raw() as *const u32) };
         self.claim_complete[context_id.raw()] = irq;
     }
@@ -89,11 +103,11 @@ impl Plic {
         &self,
         dst_addr: HostPhysicalAddress,
     ) -> Result<u32, DeviceEmulateError> {
-        if !(self.base_addr..self.base_addr + self.size).contains(&dst_addr) {
+        if !(self.base_addr()..self.base_addr() + self.size()).contains(&dst_addr) {
             return Err(DeviceEmulateError::InvalidAddress);
         }
 
-        let offset = dst_addr.raw() - self.base_addr.raw();
+        let offset = dst_addr.raw() - self.base_addr().raw();
         match offset {
             CONTEXT_BASE..=CONTEXT_END => self.context_load(offset),
             _ => Err(DeviceEmulateError::InvalidAddress),
@@ -109,7 +123,7 @@ impl Plic {
         dst_addr: HostPhysicalAddress,
         value: u32,
     ) -> Result<(), DeviceEmulateError> {
-        let offset = dst_addr.raw() - self.base_addr.raw();
+        let offset = dst_addr.raw() - self.base_addr().raw();
         let context_id = (offset - CONTEXT_BASE) / CONTEXT_REGS_SIZE;
         let offset_per_context = offset % CONTEXT_REGS_SIZE;
         match offset_per_context {
@@ -151,11 +165,11 @@ impl Plic {
         dst_addr: HostPhysicalAddress,
         value: u32,
     ) -> Result<(), DeviceEmulateError> {
-        if !(self.base_addr..self.base_addr + self.size).contains(&dst_addr) {
+        if !(self.base_addr()..self.base_addr() + self.size()).contains(&dst_addr) {
             return Err(DeviceEmulateError::InvalidAddress);
         }
 
-        let offset = dst_addr.raw() - self.base_addr.raw();
+        let offset = dst_addr.raw() - self.base_addr().raw();
         match offset {
             CONTEXT_BASE..=CONTEXT_END => self.context_storing(dst_addr, value),
             _ => Err(DeviceEmulateError::InvalidAddress),

--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -196,7 +196,7 @@ impl MmioDevice for Plic {
         self.register_map_regions
             .clone()
             .into_iter()
-            .map(|region| MemoryMap::from(region))
+            .map(MemoryMap::from)
             .collect()
     }
 }

--- a/hikami_core/src/device/rtc.rs
+++ b/hikami_core/src/device/rtc.rs
@@ -1,40 +1,37 @@
 //! RTC: Real Time Clock.
 
-use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
-use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
-use fdt::Fdt;
+use super::MmioDevice;
+use crate::memmap::MemoryMap;
+
+use alloc::vec::Vec;
+use fdt::{Fdt, standard_nodes::MemoryRegion};
 
 /// RTC: Real Time Clock.
 /// An electronic device that measures the passage of time.
 #[derive(Debug)]
 pub struct Rtc {
-    /// Base address of memory map.
-    base_addr: HostPhysicalAddress,
-    /// Memory map size.
-    size: usize,
+    /// Memory maps for memory mapped register.
+    register_map_regions: Vec<MemoryRegion>,
 }
 
 impl MmioDevice for Rtc {
     fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let region = device_tree
+        let register_map_regions: Vec<MemoryRegion> = device_tree
             .find_compatible(compatibles)?
             .reg()
             .unwrap()
-            .next()
-            .unwrap();
+            .collect();
 
         Some(Rtc {
-            base_addr: HostPhysicalAddress(region.starting_address as usize),
-            size: region.size.unwrap(),
+            register_map_regions,
         })
     }
 
-    fn memmap(&self) -> MemoryMap {
-        let vaddr = GuestPhysicalAddress(self.paddr().raw());
-        MemoryMap::new(
-            vaddr..vaddr + self.size(),
-            self.paddr()..self.paddr() + self.size(),
-            &PTE_FLAGS_FOR_DEVICE,
-        )
+    fn memmap(&self) -> Vec<MemoryMap> {
+        self.register_map_regions
+            .clone()
+            .into_iter()
+            .map(|region| MemoryMap::from(region))
+            .collect()
     }
 }

--- a/hikami_core/src/device/rtc.rs
+++ b/hikami_core/src/device/rtc.rs
@@ -29,14 +29,6 @@ impl MmioDevice for Rtc {
         })
     }
 
-    fn size(&self) -> usize {
-        self.size
-    }
-
-    fn paddr(&self) -> HostPhysicalAddress {
-        self.base_addr
-    }
-
     fn memmap(&self) -> MemoryMap {
         let vaddr = GuestPhysicalAddress(self.paddr().raw());
         MemoryMap::new(

--- a/hikami_core/src/device/rtc.rs
+++ b/hikami_core/src/device/rtc.rs
@@ -31,7 +31,7 @@ impl MmioDevice for Rtc {
         self.register_map_regions
             .clone()
             .into_iter()
-            .map(|region| MemoryMap::from(region))
+            .map(MemoryMap::from)
             .collect()
     }
 }

--- a/hikami_core/src/device/uart.rs
+++ b/hikami_core/src/device/uart.rs
@@ -55,7 +55,7 @@ impl MmioDevice for Uart {
         self.register_map_regions
             .clone()
             .into_iter()
-            .map(|region| MemoryMap::from(region))
+            .map(MemoryMap::from)
             .collect()
     }
 }

--- a/hikami_core/src/device/uart.rs
+++ b/hikami_core/src/device/uart.rs
@@ -1,10 +1,11 @@
 //! UART: Universal Asynchronous Receiver-Transmitter
 
-use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
-use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
+use super::MmioDevice;
+use crate::memmap::{HostPhysicalAddress, MemoryMap};
 
+use alloc::vec::Vec;
 use core::cell::OnceCell;
-use fdt::Fdt;
+use fdt::{Fdt, standard_nodes::MemoryRegion};
 use spin::Mutex;
 
 mod register {
@@ -20,45 +21,41 @@ static UART_ADDR: Mutex<OnceCell<HostPhysicalAddress>> = Mutex::new(OnceCell::ne
 /// UART: Universal asynchronous receiver-transmitter
 #[derive(Debug)]
 pub struct Uart {
-    /// Base address of memory map.
-    base_addr: HostPhysicalAddress,
-    /// Memory map size.
-    size: usize,
+    /// Memory maps for memory mapped register.
+    register_map_regions: Vec<MemoryRegion>,
 }
 
 impl Uart {
     /// Return address of LSR register.
     #[must_use]
     pub fn lsr_addr(&self) -> HostPhysicalAddress {
-        self.base_addr + register::LSR_OFFSET
+        HostPhysicalAddress(self.register_map_regions[0].starting_address as usize)
+            + register::LSR_OFFSET
     }
 }
 
 impl MmioDevice for Uart {
     fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let region = device_tree
+        let register_map_regions: Vec<MemoryRegion> = device_tree
             .find_compatible(compatibles)?
             .reg()
             .unwrap()
-            .next()
-            .unwrap();
+            .collect();
 
         UART_ADDR
             .lock()
-            .get_or_init(|| HostPhysicalAddress(region.starting_address as usize));
+            .get_or_init(|| HostPhysicalAddress(register_map_regions[0].starting_address as usize));
 
         Some(Uart {
-            base_addr: HostPhysicalAddress(region.starting_address as usize),
-            size: region.size.unwrap(),
+            register_map_regions,
         })
     }
 
-    fn memmap(&self) -> MemoryMap {
-        let vaddr = GuestPhysicalAddress(self.paddr().raw());
-        MemoryMap::new(
-            vaddr..vaddr + self.size(),
-            self.paddr()..self.paddr() + self.size(),
-            &PTE_FLAGS_FOR_DEVICE,
-        )
+    fn memmap(&self) -> Vec<MemoryMap> {
+        self.register_map_regions
+            .clone()
+            .into_iter()
+            .map(|region| MemoryMap::from(region))
+            .collect()
     }
 }

--- a/hikami_core/src/device/uart.rs
+++ b/hikami_core/src/device/uart.rs
@@ -53,14 +53,6 @@ impl MmioDevice for Uart {
         })
     }
 
-    fn size(&self) -> usize {
-        self.size
-    }
-
-    fn paddr(&self) -> HostPhysicalAddress {
-        self.base_addr
-    }
-
     fn memmap(&self) -> MemoryMap {
         let vaddr = GuestPhysicalAddress(self.paddr().raw());
         MemoryMap::new(

--- a/hikami_core/src/device/virtio.rs
+++ b/hikami_core/src/device/virtio.rs
@@ -1,10 +1,11 @@
 //! A virtualization standard for network and disk device drivers.
 
-use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
-use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
+use super::MmioDevice;
+use crate::memmap::MemoryMap;
+
 use alloc::vec::Vec;
 use core::slice::Iter;
-use fdt::Fdt;
+use fdt::{Fdt, standard_nodes::MemoryRegion};
 
 /// A virtualization standard for network and disk device drivers.
 /// Since more than one may be found, we will temporarily use the first one.
@@ -18,11 +19,10 @@ impl VirtIoList {
             device_tree
                 .find_all_nodes(node_path)
                 .map(|node| {
-                    let region = node.reg().unwrap().next().unwrap();
+                    let register_map_regions: Vec<MemoryRegion> = node.reg().unwrap().collect();
                     let irq = node.property("interrupts").unwrap().value[0];
                     VirtIo {
-                        base_addr: HostPhysicalAddress(region.starting_address as usize),
-                        size: region.size.unwrap(),
+                        register_map_regions,
                         irq,
                     }
                 })
@@ -39,10 +39,8 @@ impl VirtIoList {
 /// Virtualization standard for IO device.
 #[derive(Debug)]
 pub struct VirtIo {
-    /// Base address of memory map.
-    base_addr: HostPhysicalAddress,
-    /// Memory map size.
-    size: usize,
+    /// Memory maps for memory mapped register.
+    register_map_regions: Vec<MemoryRegion>,
     /// Interrupt Reqeust bit.
     irq: u8,
 }
@@ -57,22 +55,21 @@ impl VirtIo {
 impl MmioDevice for VirtIo {
     fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
         let node = device_tree.find_compatible(compatibles)?;
-        let region = node.reg().unwrap().next().unwrap();
+        let register_map_regions: Vec<MemoryRegion> = node.reg().unwrap().collect();
+
         let irq = node.property("interrupts").unwrap().value[0];
 
         Some(VirtIo {
-            base_addr: HostPhysicalAddress(region.starting_address as usize),
-            size: region.size.unwrap(),
+            register_map_regions,
             irq,
         })
     }
 
-    fn memmap(&self) -> MemoryMap {
-        let vaddr = GuestPhysicalAddress(self.paddr().raw());
-        MemoryMap::new(
-            vaddr..vaddr + self.size(),
-            self.paddr()..self.paddr() + self.size(),
-            &PTE_FLAGS_FOR_DEVICE,
-        )
+    fn memmap(&self) -> Vec<MemoryMap> {
+        self.register_map_regions
+            .clone()
+            .into_iter()
+            .map(|region| MemoryMap::from(region))
+            .collect()
     }
 }

--- a/hikami_core/src/device/virtio.rs
+++ b/hikami_core/src/device/virtio.rs
@@ -67,14 +67,6 @@ impl MmioDevice for VirtIo {
         })
     }
 
-    fn size(&self) -> usize {
-        self.size
-    }
-
-    fn paddr(&self) -> HostPhysicalAddress {
-        self.base_addr
-    }
-
     fn memmap(&self) -> MemoryMap {
         let vaddr = GuestPhysicalAddress(self.paddr().raw());
         MemoryMap::new(

--- a/hikami_core/src/device/virtio.rs
+++ b/hikami_core/src/device/virtio.rs
@@ -69,7 +69,7 @@ impl MmioDevice for VirtIo {
         self.register_map_regions
             .clone()
             .into_iter()
-            .map(|region| MemoryMap::from(region))
+            .map(MemoryMap::from)
             .collect()
     }
 }

--- a/hikami_core/src/memmap.rs
+++ b/hikami_core/src/memmap.rs
@@ -122,3 +122,23 @@ impl MemoryMap {
         }
     }
 }
+
+impl From<fdt::standard_nodes::MemoryRegion> for MemoryMap {
+    fn from(region: fdt::standard_nodes::MemoryRegion) -> Self {
+        let size = region.size.unwrap();
+        let virt_start = GuestPhysicalAddress(region.starting_address as usize);
+        let phys_start = HostPhysicalAddress(region.starting_address as usize);
+        MemoryMap::new(
+            virt_start..virt_start + size,
+            phys_start..phys_start + size,
+            &[
+                PteFlag::Dirty,
+                PteFlag::Accessed,
+                PteFlag::Write,
+                PteFlag::Read,
+                PteFlag::User,
+                PteFlag::Valid,
+            ],
+        )
+    }
+}

--- a/hikami_core/src/memmap/page_table/sv39x4.rs
+++ b/hikami_core/src/memmap/page_table/sv39x4.rs
@@ -104,13 +104,11 @@ pub fn generate_page_table(root_table_start_addr: HostPhysicalAddress, memmaps: 
 
         assert!(
             memmap.virt.start % trans_page_level.size() == 0,
-            "memmap: {:#x?}",
-            memmap
+            "memmap: {memmap:#x?}"
         );
         assert!(
             memmap.phys.start % trans_page_level.size() == 0,
-            "memmap: {:#x?}",
-            memmap
+            "memmap: {memmap:#x?}"
         );
 
         for offset in (0..memmap.virt.len()).step_by(trans_page_level.size()) {

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -2,23 +2,23 @@
 
 use crate::trap::hstrap_vector;
 use crate::{ALLOCATOR, GUEST_DTB, GUEST_INITRD, GUEST_KERNEL};
-use hikami_core::guest::context::ContextData;
 use hikami_core::guest::Guest;
+use hikami_core::guest::context::ContextData;
 use hikami_core::h_extension::csrs::{
-    hcounteren, hedeleg, hedeleg::ExceptionKind, henvcfg, hgatp, hideleg, hie, hstatus, hvip,
-    vsatp, VsInterruptKind,
+    VsInterruptKind, hcounteren, hedeleg, hedeleg::ExceptionKind, henvcfg, hgatp, hideleg, hie,
+    hstatus, hvip, vsatp,
 };
 use hikami_core::h_extension::instruction::hfence_gvma_all;
 use hikami_core::memmap::{
-    constant::guest_memory, page_table::sv39x4::ROOT_PAGE_TABLE, GuestPhysicalAddress,
-    HostPhysicalAddress,
+    GuestPhysicalAddress, HostPhysicalAddress, constant::guest_memory,
+    page_table::sv39x4::ROOT_PAGE_TABLE,
 };
-use hikami_core::{HypervisorData, HYPERVISOR_DATA};
 use hikami_core::{_hv_heap_size, _start_heap};
+use hikami_core::{HYPERVISOR_DATA, HypervisorData};
 
 use core::arch::asm;
 
-use elf::{endian::AnyEndian, ElfBytes};
+use elf::{ElfBytes, endian::AnyEndian};
 use riscv::register::{sepc, sie, sscratch, sstatus, sstatus::FS, stvec};
 
 /// Entry point to HS-mode.

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -2,23 +2,23 @@
 
 use crate::trap::hstrap_vector;
 use crate::{ALLOCATOR, GUEST_DTB, GUEST_INITRD, GUEST_KERNEL};
-use hikami_core::guest::Guest;
 use hikami_core::guest::context::ContextData;
+use hikami_core::guest::Guest;
 use hikami_core::h_extension::csrs::{
-    VsInterruptKind, hcounteren, hedeleg, hedeleg::ExceptionKind, henvcfg, hgatp, hideleg, hie,
-    hstatus, hvip, vsatp,
+    hcounteren, hedeleg, hedeleg::ExceptionKind, henvcfg, hgatp, hideleg, hie, hstatus, hvip,
+    vsatp, VsInterruptKind,
 };
 use hikami_core::h_extension::instruction::hfence_gvma_all;
 use hikami_core::memmap::{
-    GuestPhysicalAddress, HostPhysicalAddress, constant::guest_memory,
-    page_table::sv39x4::ROOT_PAGE_TABLE,
+    constant::guest_memory, page_table::sv39x4::ROOT_PAGE_TABLE, GuestPhysicalAddress,
+    HostPhysicalAddress,
 };
+use hikami_core::{HypervisorData, HYPERVISOR_DATA};
 use hikami_core::{_hv_heap_size, _start_heap};
-use hikami_core::{HYPERVISOR_DATA, HypervisorData};
 
 use core::arch::asm;
 
-use elf::{ElfBytes, endian::AnyEndian};
+use elf::{endian::AnyEndian, ElfBytes};
 use riscv::register::{sepc, sie, sscratch, sstatus, sstatus::FS, stvec};
 
 /// Entry point to HS-mode.


### PR DESCRIPTION
- Remove `MmioDevice::size` and `MmioDevice::paddr`.
- Change the return type of `MmioDevice::memmap`.
- Change some member of mmio devices.