### PR TITLE
Change memory mapping method

### DIFF
--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -1,13 +1,13 @@
 //! PLIC: Platform-Level Interrupt Controller  
 //! ref: [https://github.com/riscv/riscv-plic-spec/releases/download/1.0.0/riscv-plic-1.0.0.pdf](https://github.com/riscv/riscv-plic-spec/releases/download/1.0.0/riscv-plic-1.0.0.pdf)
 
-use super::{DeviceEmulateError, MmioDevice};
-use crate::h_extension::csrs::{VsInterruptKind, hvip};
+use super::{DeviceEmulateError, MmioDevice, PTE_FLAGS_FOR_DEVICE};
+use crate::h_extension::csrs::{hvip, VsInterruptKind};
 use crate::memmap::constant::MAX_HART_NUM;
-use crate::memmap::{HostPhysicalAddress, MemoryMap};
+use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
 
 use alloc::vec::Vec;
-use fdt::{Fdt, standard_nodes::MemoryRegion};
+use fdt::{standard_nodes::MemoryRegion, Fdt};
 use riscv::register::sie;
 
 /// Max number of PLIC context.
@@ -193,10 +193,20 @@ impl MmioDevice for Plic {
     }
 
     fn memmap(&self) -> Vec<MemoryMap> {
+        // Pass through 0x0 - 0x20_0000.
+        // Disallow 0x20_0000 - for emulation.
         self.register_map_regions
             .clone()
             .into_iter()
-            .map(MemoryMap::from)
+            .map(|region| {
+                let virt_start = GuestPhysicalAddress(region.starting_address as usize);
+                let phys_start = HostPhysicalAddress(region.starting_address as usize);
+                MemoryMap::new(
+                    virt_start..virt_start + CONTEXT_BASE,
+                    phys_start..phys_start + CONTEXT_BASE,
+                    &PTE_FLAGS_FOR_DEVICE,
+                )
+            })
             .collect()
     }
 }

--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -2,12 +2,12 @@
 //! ref: [https://github.com/riscv/riscv-plic-spec/releases/download/1.0.0/riscv-plic-1.0.0.pdf](https://github.com/riscv/riscv-plic-spec/releases/download/1.0.0/riscv-plic-1.0.0.pdf)
 
 use super::{DeviceEmulateError, MmioDevice, PTE_FLAGS_FOR_DEVICE};
-use crate::h_extension::csrs::{hvip, VsInterruptKind};
+use crate::h_extension::csrs::{VsInterruptKind, hvip};
 use crate::memmap::constant::MAX_HART_NUM;
 use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
 
 use alloc::vec::Vec;
-use fdt::{standard_nodes::MemoryRegion, Fdt};
+use fdt::{Fdt, standard_nodes::MemoryRegion};
 use riscv::register::sie;
 
 /// Max number of PLIC context.

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -255,25 +255,11 @@ impl Guest {
     }
 
     /// Allocate guest memory space from heap and create corresponding page table.
-    pub fn allocate_memory_region(
-        &self,
-        region: Range<GuestPhysicalAddress>,
-        guest_initrd: &'static [u8],
-    ) {
+    pub fn allocate_memory_region(&self, region: Range<GuestPhysicalAddress>) {
         use PteFlag::{Accessed, Dirty, Exec, Read, User, Valid, Write};
 
         const ALL_PTE_FLAGS_ARE_SET: &[PteFlag; 7] =
             &[Dirty, Accessed, Exec, Write, Read, User, Valid];
-
-        let aligned_initrd_size = guest_initrd.len().div_ceil(PAGE_SIZE) * PAGE_SIZE;
-        let initrd_start = region.end - aligned_initrd_size;
-        if !guest_initrd.is_empty() {
-            crate::println!(
-                "initrd (GPA): {:#x}..{:#x}",
-                initrd_start.raw(),
-                initrd_start.raw() + guest_initrd.len()
-            );
-        }
 
         for guest_physical_addr in (region.start.raw()..region.end.raw()).step_by(PAGE_SIZE) {
             let guest_physical_addr = GuestPhysicalAddress(guest_physical_addr);

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -88,8 +88,15 @@ impl Guest {
         for offset in (0..aligned_dtb_size).step_by(PAGE_SIZE) {
             let guest_physical_addr = guest_dtb_addr + offset;
 
-            // allocate memory from heap
-            let aligned_page_size_block_addr = PageBlock::alloc();
+            // get page address
+            let aligned_page_size_block_addr: HostPhysicalAddress =
+                if cfg!(feature = "identity_map") {
+                    // identity map
+                    HostPhysicalAddress(guest_physical_addr.raw())
+                } else {
+                    // allocate memory from heap
+                    PageBlock::alloc()
+                };
 
             // copy elf segment to new heap block
             unsafe {

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -167,16 +167,15 @@ impl Guest {
         elf_addr: *const u8,
         _guest_initrd: &'static [u8],
     ) -> GuestPhysicalAddress {
+        use PteFlag::{Accessed, Dirty, Read, User, Valid};
+
         /// Segment type `PT_LOAD`
         ///
         /// The array element specifies a loadable segment, described by `p_filesz` and `p_memsz`.
         const PT_LOAD: u32 = 1;
 
-        use PteFlag::{Accessed, Dirty, Read, User, Valid};
-
         let align_size =
             |size: u64, align: u64| usize::try_from((size + (align - 1)) & !(align - 1)).unwrap();
-        let mut elf_end: GuestPhysicalAddress = GuestPhysicalAddress::default();
 
         for prog_header in guest_elf
             .segments()
@@ -193,12 +192,16 @@ impl Guest {
                 for offset in (0..aligned_segment_size).step_by(PAGE_SIZE) {
                     let guest_physical_addr =
                         self.dram_base() + prog_header.p_paddr.try_into().unwrap() + offset;
-                    elf_end = core::cmp::max(elf_end, guest_physical_addr + PAGE_SIZE);
 
-                    // allocate memory from heap
+                    // determine page address
                     let aligned_page_size_block_addr: HostPhysicalAddress =
-                        page_table::sv39x4::trans_addr(guest_physical_addr)
-                            .expect("failed to translate guest memory address in mapping");
+                        if cfg!(feature = "identity_map") {
+                            HostPhysicalAddress(guest_physical_addr.raw())
+                        } else {
+                            // translate allocated address (GPA) -> HPA
+                            page_table::sv39x4::trans_addr(guest_physical_addr)
+                                .expect("failed to translate guest memory address in mapping")
+                        };
 
                     // Determine the range of data to copy
                     let copy_start = segment_file_offset + offset;
@@ -209,8 +212,8 @@ impl Guest {
                     };
 
                     unsafe {
+                        // Copy ELF segment data from file
                         if copy_size > 0 {
-                            // Copy ELF segment data from file
                             core::ptr::copy(
                                 elf_addr.wrapping_add(copy_start),
                                 aligned_page_size_block_addr.raw() as *mut u8,
@@ -218,8 +221,8 @@ impl Guest {
                             );
                         }
 
+                        // Zero-initialize the remaining part of the page
                         if copy_size < PAGE_SIZE {
-                            // Zero-initialize the remaining part of the page
                             core::ptr::write_bytes(
                                 (aligned_page_size_block_addr.raw() as *mut u8).add(copy_size),
                                 0,
@@ -228,6 +231,7 @@ impl Guest {
                         }
                     }
 
+                    // update page flags
                     #[allow(clippy::match_same_arms)]
                     match prog_header.p_flags & 0b111 {
                         // update page flags to `[Dirty, Accessed, Read, User, Valid]`

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -56,7 +56,7 @@ impl Guest {
         page_table::sv39x4::initialize_page_table(page_table_addr);
 
         // load guest dtb to memory
-        let dtb_addr = Self::map_guest_dtb(hart_id, page_table_addr, guest_dtb);
+        let dtb_addr = Self::load_guest_dtb(hart_id, page_table_addr, guest_dtb);
 
         Guest {
             hart_id,
@@ -71,7 +71,7 @@ impl Guest {
     /// Load guest device tree and create corresponding page table
     ///
     /// Guest device tree will be placed start of guest memory region.
-    fn map_guest_dtb(
+    fn load_guest_dtb(
         hart_id: usize,
         page_table_addr: HostPhysicalAddress,
         guest_dtb: &'static [u8],

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -296,7 +296,7 @@ impl Guest {
         /// The array element specifies a loadable segment, described by `p_filesz` and `p_memsz`.
         const PT_LOAD: u32 = 1;
 
-        use PteFlag::{Accessed, Dirty, Exec, Read, User, Valid, Write};
+        use PteFlag::{Accessed, Dirty, Read, User, Valid};
 
         let align_size =
             |size: u64, align: u64| usize::try_from((size + (align - 1)) & !(align - 1)).unwrap();
@@ -320,7 +320,9 @@ impl Guest {
                     elf_end = core::cmp::max(elf_end, guest_physical_addr + PAGE_SIZE);
 
                     // allocate memory from heap
-                    let aligned_page_size_block_addr = PageBlock::alloc();
+                    let aligned_page_size_block_addr: HostPhysicalAddress =
+                        page_table::sv39x4::trans_addr(guest_physical_addr)
+                            .expect("failed to translate guest memory address in mapping");
 
                     // Determine the range of data to copy
                     let copy_start = segment_file_offset + offset;
@@ -350,26 +352,25 @@ impl Guest {
                         }
                     }
 
-                    // create memory mapping
-                    page_table::sv39x4::generate_page_table(
-                        self.page_table_addr,
-                        &[MemoryMap::new(
-                            guest_physical_addr..guest_physical_addr + PAGE_SIZE,
-                            aligned_page_size_block_addr..aligned_page_size_block_addr + PAGE_SIZE,
-                            match prog_header.p_flags & 0b111 {
-                                0b100 => &[Dirty, Accessed, Read, User, Valid],
-                                #[allow(clippy::match_same_arms)]
-                                // Add Write permission to RX for dynamic patch
-                                // ref: https://github.com/torvalds/linux/blob/67784a74e258a467225f0e68335df77acd67b7ab/arch/riscv/kernel/patch.c#L215C5-L215C21
-                                // TODO: switch enable/disable write permission corresponding to VS-stage page table.
-                                0b101 => &[Dirty, Accessed, Read, Write, Exec, User, Valid],
-                                // FIXME: Add Exec permission (RW -> RWX)
-                                0b110 => &[Dirty, Accessed, Read, Write, Exec, User, Valid],
-                                0b111 => &[Dirty, Accessed, Exec, Write, Read, User, Valid],
-                                _ => panic!("unsupported flags"),
-                            },
-                        )],
-                    );
+                    #[allow(clippy::match_same_arms)]
+                    match prog_header.p_flags & 0b111 {
+                        // update page flags to `[Dirty, Accessed, Read, User, Valid]`
+                        0b100 => page_table::sv39x4::update_page_flags(
+                            guest_physical_addr,
+                            [Dirty, Accessed, Read, User, Valid]
+                                .iter()
+                                .fold(0, |pte_f, f| (pte_f | *f as u8)),
+                        )
+                        .expect("failed to update page flags"),
+                        // Add Write permission to RX for dynamic patch
+                        // ref: https://github.com/torvalds/linux/blob/67784a74e258a467225f0e68335df77acd67b7ab/arch/riscv/kernel/patch.c#L215C5-L215C21
+                        // TODO: switch enable/disable write permission corresponding to VS-stage page table.
+                        0b101 => (), // no update
+                        // FIXME: Add Exec permission (RW -> RWX)
+                        0b110 => (), // no update
+                        0b111 => (), // no update
+                        _ => panic!("unsupported flags"),
+                    }
                 }
             }
         }
@@ -386,7 +387,7 @@ impl Guest {
     ) {
         use PteFlag::{Accessed, Dirty, Exec, Read, User, Valid, Write};
 
-        const all_pte_flags_are_set: &[PteFlag; 7] =
+        const ALL_PTE_FLAGS_ARE_SET: &[PteFlag; 7] =
             &[Dirty, Accessed, Exec, Write, Read, User, Valid];
 
         for guest_physical_addr in (region.start.raw()..region.end.raw()).step_by(PAGE_SIZE) {
@@ -398,7 +399,7 @@ impl Guest {
                 &[MemoryMap::new(
                     guest_physical_addr..guest_physical_addr + PAGE_SIZE,
                     host_physical_addr..host_physical_addr + PAGE_SIZE,
-                    all_pte_flags_are_set,
+                    ALL_PTE_FLAGS_ARE_SET,
                 )],
             );
         }
@@ -413,7 +414,7 @@ impl Guest {
     ) {
         use PteFlag::{Accessed, Dirty, Exec, Read, User, Valid, Write};
 
-        const all_pte_flags_are_set: &[PteFlag; 7] =
+        const ALL_PTE_FLAGS_ARE_SET: &[PteFlag; 7] =
             &[Dirty, Accessed, Exec, Write, Read, User, Valid];
 
         let aligned_initrd_size = guest_initrd.len().div_ceil(PAGE_SIZE) * PAGE_SIZE;
@@ -450,7 +451,7 @@ impl Guest {
                 &[MemoryMap::new(
                     guest_physical_addr..guest_physical_addr + PAGE_SIZE,
                     aligned_page_size_block_addr..aligned_page_size_block_addr + PAGE_SIZE,
-                    all_pte_flags_are_set,
+                    ALL_PTE_FLAGS_ARE_SET,
                 )],
             );
         }

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -71,41 +71,6 @@ impl Guest {
     /// Load guest device tree and create corresponding page table
     ///
     /// Guest device tree will be placed start of guest memory region.
-    #[cfg(feature = "identity_map")]
-    fn map_guest_dtb(
-        _hart_id: usize,
-        page_table_addr: HostPhysicalAddress,
-        guest_dtb: &'static [u8],
-    ) -> GuestPhysicalAddress {
-        use PteFlag::{Accessed, Dirty, Read, User, Valid, Write};
-
-        assert!(guest_dtb.len() < guest_memory::GUEST_DTB_REGION_SIZE);
-
-        let aligned_dtb_size = guest_dtb.len().div_ceil(PAGE_SIZE) * PAGE_SIZE;
-
-        for offset in (0..aligned_dtb_size).step_by(PAGE_SIZE) {
-            let guest_physical_addr = GuestPhysicalAddress(guest_dtb.as_ptr() as usize + offset);
-            let host_physical_addr = HostPhysicalAddress(guest_physical_addr.raw());
-
-            // create memory mapping
-            page_table::sv39x4::generate_page_table(
-                page_table_addr,
-                &[MemoryMap::new(
-                    guest_physical_addr..guest_physical_addr + PAGE_SIZE,
-                    host_physical_addr..host_physical_addr + PAGE_SIZE,
-                    // allow writing data to dtb to modify device tree on guest OS.
-                    &[Dirty, Accessed, Write, Read, User, Valid],
-                )],
-            );
-        }
-
-        GuestPhysicalAddress(guest_dtb.as_ptr() as usize)
-    }
-
-    /// Load guest device tree and create corresponding page table
-    ///
-    /// Guest device tree will be placed start of guest memory region.
-    #[cfg(not(feature = "identity_map"))]
     fn map_guest_dtb(
         hart_id: usize,
         page_table_addr: HostPhysicalAddress,
@@ -179,94 +144,6 @@ impl Guest {
         self.memory_region.start
     }
 
-    /// Load an elf to guest memory page.
-    ///
-    /// It only load `PT_LOAD` type segments.
-    /// Entry address is base address of the dram.
-    ///
-    /// # Return
-    /// - Entry point address in Guest memory space.
-    /// - End address of the ELF. (for filling remind memory space)
-    ///
-    /// # Arguments
-    /// * `guest_elf` - Elf loading guest space.
-    /// * `elf_addr` - Elf address.
-    /// * `guest_initrd` - Initrd raw slice.
-    #[cfg(feature = "identity_map")]
-    pub fn load_guest_elf(
-        &self,
-        guest_elf: &ElfBytes<AnyEndian>,
-        elf_addr: *const u8,
-        guest_initrd: &'static [u8],
-    ) -> GuestPhysicalAddress {
-        /// Segment type `PT_LOAD`
-        ///
-        /// The array element specifies a loadable segment, described by `p_filesz` and `p_memsz`.
-        const PT_LOAD: u32 = 1;
-
-        let mut elf_end: GuestPhysicalAddress = GuestPhysicalAddress::default();
-
-        for prog_header in guest_elf
-            .segments()
-            .expect("failed to get segments from elf")
-            .iter()
-        {
-            if prog_header.p_type == PT_LOAD {
-                let segment_gpa = GuestPhysicalAddress(
-                    guest_memory::DRAM_BASE.raw()
-                        + guest_memory::DRAM_SIZE_PER_GUEST * (self.hart_id + 1)
-                        + prog_header.p_paddr as usize,
-                );
-                elf_end = core::cmp::max(
-                    elf_end,
-                    segment_gpa + prog_header.p_memsz as usize + PAGE_SIZE,
-                );
-                unsafe {
-                    core::ptr::copy(
-                        elf_addr.wrapping_add(prog_header.p_offset as usize) as *const u8,
-                        segment_gpa.raw() as *mut u8,
-                        prog_header.p_memsz as usize,
-                    );
-                }
-
-                if prog_header.p_memsz > prog_header.p_filesz {
-                    unsafe {
-                        core::ptr::write_bytes(
-                            elf_addr.wrapping_add(
-                                prog_header.p_offset as usize + prog_header.p_filesz as usize,
-                            ) as *mut u8,
-                            0,
-                            (prog_header.p_memsz - prog_header.p_filesz) as usize,
-                        );
-                    }
-                }
-            }
-        }
-
-        if !guest_initrd.is_empty() {
-            let aligned_initrd_size = guest_initrd.len().div_ceil(PAGE_SIZE) * PAGE_SIZE;
-            let guest_base =
-                guest_memory::DRAM_BASE + guest_memory::DRAM_SIZE_PER_GUEST * (self.hart_id + 1);
-            let initrd_start = guest_base + guest_memory::DRAM_SIZE_PER_GUEST - aligned_initrd_size;
-
-            crate::println!(
-                "initrd (GPA): {:#x}..{:#x}",
-                initrd_start.raw(),
-                initrd_start.raw() + guest_initrd.len()
-            );
-
-            unsafe {
-                core::ptr::copy(
-                    guest_initrd.as_ptr(),
-                    initrd_start.raw() as *mut u8,
-                    guest_initrd.len(),
-                );
-            }
-        }
-
-        self.dram_base()
-    }
-
     /// Load an elf to new allocated guest memory page.
     ///
     /// It only load `PT_LOAD` type segments.
@@ -283,7 +160,6 @@ impl Guest {
     ///
     /// # Panics
     /// Panics if it failed to calculate `aligned_segment_size` or failed to convert to usize.
-    #[cfg(not(feature = "identity_map"))]
     #[must_use]
     pub fn load_guest_elf(
         &self,
@@ -379,34 +255,6 @@ impl Guest {
     }
 
     /// Allocate guest memory space from heap and create corresponding page table.
-    #[cfg(feature = "identity_map")]
-    pub fn allocate_memory_region(
-        &self,
-        region: Range<GuestPhysicalAddress>,
-        _guest_initrd: &'static [u8],
-    ) {
-        use PteFlag::{Accessed, Dirty, Exec, Read, User, Valid, Write};
-
-        const ALL_PTE_FLAGS_ARE_SET: &[PteFlag; 7] =
-            &[Dirty, Accessed, Exec, Write, Read, User, Valid];
-
-        for guest_physical_addr in (region.start.raw()..region.end.raw()).step_by(PAGE_SIZE) {
-            let guest_physical_addr = GuestPhysicalAddress(guest_physical_addr);
-            let host_physical_addr = HostPhysicalAddress(guest_physical_addr.raw());
-            // create memory mapping
-            page_table::sv39x4::generate_page_table(
-                self.page_table_addr,
-                &[MemoryMap::new(
-                    guest_physical_addr..guest_physical_addr + PAGE_SIZE,
-                    host_physical_addr..host_physical_addr + PAGE_SIZE,
-                    ALL_PTE_FLAGS_ARE_SET,
-                )],
-            );
-        }
-    }
-
-    /// Allocate guest memory space from heap and create corresponding page table.
-    #[cfg(not(feature = "identity_map"))]
     pub fn allocate_memory_region(
         &self,
         region: Range<GuestPhysicalAddress>,
@@ -432,18 +280,6 @@ impl Guest {
 
             // allocate memory from heap
             let aligned_page_size_block_addr = PageBlock::alloc();
-
-            // copy initrd to new heap block
-            if (initrd_start..region.end).contains(&guest_physical_addr) {
-                unsafe {
-                    let offset = guest_physical_addr.raw() - initrd_start.raw();
-                    core::ptr::copy(
-                        guest_initrd.as_ptr().byte_add(offset),
-                        aligned_page_size_block_addr.raw() as *mut u8,
-                        PAGE_SIZE,
-                    );
-                }
-            }
 
             // create memory mapping
             page_table::sv39x4::generate_page_table(

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -2,18 +2,18 @@
 
 pub mod context;
 
+use crate::PageBlock;
 use crate::memmap::page_table::sv39x4::FIRST_LV_PAGE_TABLE_LEN;
 use crate::memmap::{
+    GuestPhysicalAddress, HostPhysicalAddress, MemoryMap,
     constant::guest_memory,
     page_table,
-    page_table::{constants::PAGE_SIZE, PageTableEntry, PteFlag},
-    GuestPhysicalAddress, HostPhysicalAddress, MemoryMap,
+    page_table::{PageTableEntry, PteFlag, constants::PAGE_SIZE},
 };
-use crate::PageBlock;
 use context::{Context, ContextData};
 
 use core::ops::Range;
-use elf::{endian::AnyEndian, ElfBytes};
+use elf::{ElfBytes, endian::AnyEndian};
 
 /// Guest Information
 #[derive(Debug)]
@@ -242,10 +242,13 @@ impl Guest {
     /// * `elf_addr` - Elf address.
     /// * `guest_initrd` - Initrd raw slice.
     ///
+    /// # Safety
+    /// This function will be safe if `elf_addr` is valid pointer.
+    ///
     /// # Panics
     /// Panics if it failed to calculate `aligned_segment_size` or failed to convert to usize.
     #[must_use]
-    pub fn load_guest_elf(
+    pub unsafe fn load_guest_elf(
         &self,
         guest_elf: &ElfBytes<AnyEndian>,
         elf_addr: *const u8,

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -92,19 +92,18 @@ impl Guest {
             let guest_physical_addr = initrd_start + offset;
 
             // get page host physical address
-            let aligned_page_size_block_addr: HostPhysicalAddress =
-                if cfg!(feature = "identity_map") {
-                    // identity map
-                    HostPhysicalAddress(guest_physical_addr.raw())
-                } else {
-                    // allocate memory from heap
-                    PageBlock::alloc()
-                };
+            let page_size_block_addr: HostPhysicalAddress = if cfg!(feature = "identity_map") {
+                // identity map
+                HostPhysicalAddress(guest_physical_addr.raw())
+            } else {
+                // allocate memory from heap
+                PageBlock::alloc()
+            };
 
             unsafe {
                 core::ptr::copy(
                     guest_initrd.as_ptr(),
-                    aligned_page_size_block_addr.raw() as *mut u8,
+                    page_size_block_addr.raw() as *mut u8,
                     PAGE_SIZE,
                 );
             }

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -21,6 +21,7 @@ pub struct Guest {
     /// HART ID
     hart_id: usize,
     /// Page table that is passed to guest address
+    #[allow(dead_code)]
     page_table_addr: HostPhysicalAddress,
     /// Device tree address
     dtb_addr: GuestPhysicalAddress,
@@ -56,6 +57,9 @@ impl Guest {
         // init page table
         page_table::sv39x4::initialize_page_table(page_table_addr);
 
+        // map guest memory space
+        Self::allocate_memory_region(page_table_addr, &memory_region);
+
         // load guest dtb to memory
         let dtb_addr = Self::load_guest_dtb(hart_id, page_table_addr, guest_dtb);
 
@@ -72,7 +76,40 @@ impl Guest {
         }
     }
 
-    pub fn load_initrd(hart_id: usize, guest_initrd: &'static [u8]) {
+    /// Allocate guest memory space from heap and create corresponding page table.
+    fn allocate_memory_region(
+        page_table_addr: HostPhysicalAddress,
+        region: &Range<GuestPhysicalAddress>,
+    ) {
+        use PteFlag::{Accessed, Dirty, Exec, Read, User, Valid, Write};
+
+        const ALL_PTE_FLAGS_ARE_SET: &[PteFlag; 7] =
+            &[Dirty, Accessed, Exec, Write, Read, User, Valid];
+
+        for guest_physical_addr in (region.start.raw()..region.end.raw()).step_by(PAGE_SIZE) {
+            let guest_physical_addr = GuestPhysicalAddress(guest_physical_addr);
+
+            // allocate memory from heap
+            let aligned_page_size_block_addr: HostPhysicalAddress =
+                if cfg!(feature = "identity_map") {
+                    HostPhysicalAddress(guest_physical_addr.raw())
+                } else {
+                    PageBlock::alloc()
+                };
+
+            // create memory mapping
+            page_table::sv39x4::generate_page_table(
+                page_table_addr,
+                &[MemoryMap::new(
+                    guest_physical_addr..guest_physical_addr + PAGE_SIZE,
+                    aligned_page_size_block_addr..aligned_page_size_block_addr + PAGE_SIZE,
+                    ALL_PTE_FLAGS_ARE_SET,
+                )],
+            );
+        }
+    }
+
+    fn load_initrd(hart_id: usize, guest_initrd: &'static [u8]) {
         if guest_initrd.is_empty() {
             return;
         }
@@ -304,35 +341,5 @@ impl Guest {
         }
 
         self.dram_base()
-    }
-
-    /// Allocate guest memory space from heap and create corresponding page table.
-    pub fn allocate_memory_region(&self, region: Range<GuestPhysicalAddress>) {
-        use PteFlag::{Accessed, Dirty, Exec, Read, User, Valid, Write};
-
-        const ALL_PTE_FLAGS_ARE_SET: &[PteFlag; 7] =
-            &[Dirty, Accessed, Exec, Write, Read, User, Valid];
-
-        for guest_physical_addr in (region.start.raw()..region.end.raw()).step_by(PAGE_SIZE) {
-            let guest_physical_addr = GuestPhysicalAddress(guest_physical_addr);
-
-            // allocate memory from heap
-            let aligned_page_size_block_addr: HostPhysicalAddress =
-                if cfg!(feature = "identity_map") {
-                    HostPhysicalAddress(guest_physical_addr.raw())
-                } else {
-                    PageBlock::alloc()
-                };
-
-            // create memory mapping
-            page_table::sv39x4::generate_page_table(
-                self.page_table_addr,
-                &[MemoryMap::new(
-                    guest_physical_addr..guest_physical_addr + PAGE_SIZE,
-                    aligned_page_size_block_addr..aligned_page_size_block_addr + PAGE_SIZE,
-                    ALL_PTE_FLAGS_ARE_SET,
-                )],
-            );
-        }
     }
 }

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -109,6 +109,7 @@ impl Guest {
         }
     }
 
+    /// Load guest's initrd
     fn load_initrd(hart_id: usize, guest_initrd: &'static [u8]) {
         if guest_initrd.is_empty() {
             return;
@@ -133,8 +134,9 @@ impl Guest {
                 // identity map
                 HostPhysicalAddress(guest_physical_addr.raw())
             } else {
-                // allocate memory from heap
-                PageBlock::alloc()
+                // translate allocated address (GPA) -> HPA
+                page_table::sv39x4::trans_addr(guest_physical_addr)
+                    .expect("failed to translate guest memory address in mapping")
             };
 
             unsafe {

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -2,18 +2,18 @@
 
 pub mod context;
 
-use crate::PageBlock;
 use crate::memmap::page_table::sv39x4::FIRST_LV_PAGE_TABLE_LEN;
 use crate::memmap::{
-    GuestPhysicalAddress, HostPhysicalAddress, MemoryMap,
     constant::guest_memory,
     page_table,
-    page_table::{PageTableEntry, PteFlag, constants::PAGE_SIZE},
+    page_table::{constants::PAGE_SIZE, PageTableEntry, PteFlag},
+    GuestPhysicalAddress, HostPhysicalAddress, MemoryMap,
 };
+use crate::PageBlock;
 use context::{Context, ContextData};
 
 use core::ops::Range;
-use elf::{ElfBytes, endian::AnyEndian};
+use elf::{endian::AnyEndian, ElfBytes};
 
 /// Guest Information
 #[derive(Debug)]
@@ -266,6 +266,11 @@ impl Guest {
             .iter()
         {
             if prog_header.p_type == PT_LOAD {
+                // Skip segments that have no memory footprint.
+                if prog_header.p_memsz == 0 {
+                    continue;
+                }
+
                 assert!(prog_header.p_align >= PAGE_SIZE as u64);
 
                 let aligned_segment_size = align_size(prog_header.p_memsz, prog_header.p_align);
@@ -273,38 +278,51 @@ impl Guest {
                 let segment_file_size = usize::try_from(prog_header.p_filesz).unwrap();
 
                 for offset in (0..aligned_segment_size).step_by(PAGE_SIZE) {
+                    // Calculate the target GPA: Kernel's physical base + segment's physical offset + page offset
                     let guest_physical_addr =
-                        self.dram_base() + prog_header.p_paddr.try_into().unwrap() + offset;
+                        self.dram_base() + prog_header.p_paddr as usize + offset;
 
-                    // determine page address
-                    let aligned_page_size_block_addr: HostPhysicalAddress =
-                        if cfg!(feature = "identity_map") {
-                            HostPhysicalAddress(guest_physical_addr.raw())
-                        } else {
-                            // translate allocated address (GPA) -> HPA
-                            page_table::sv39x4::trans_addr(guest_physical_addr)
-                                .expect("failed to translate guest memory address in mapping")
-                        };
+                    // Check if the target address is within the pre-allocated guest memory region
+                    if !self.memory_region.contains(&guest_physical_addr) {
+                        panic!(
+                            "ELF segment paddr {:#x} out of guest memory region {:#x?}",
+                            guest_physical_addr.raw(),
+                            self.memory_region
+                        );
+                    }
 
-                    // Determine the range of data to copy
-                    let copy_start = segment_file_offset + offset;
-                    let copy_size = if offset + PAGE_SIZE <= segment_file_size {
-                        PAGE_SIZE
+                    // Translate the GPA to the HPA that was mapped in allocate_memory_region
+                    let aligned_page_size_block_addr: HostPhysicalAddress = if cfg!(
+                        feature = "identity_map"
+                    ) {
+                        HostPhysicalAddress(guest_physical_addr.raw())
                     } else {
-                        segment_file_size.saturating_sub(offset)
+                        page_table::sv39x4::trans_addr(guest_physical_addr).unwrap_or_else(|e| {
+                                panic!(
+                                    "failed to translate guest memory address {:#x} for ELF loading: {:?}",
+                                    guest_physical_addr.raw(), e
+                                )
+                            })
                     };
 
+                    // This logic calculates how many bytes to copy from the ELF file into the current page.
+                    // It handles cases where a page is only partially covered by file data.
+                    let copy_size = (segment_file_size
+                        .saturating_sub(offset.min(segment_file_size)))
+                    .min(PAGE_SIZE);
+                    let copy_start = segment_file_offset + offset;
+
                     unsafe {
-                        // Copy ELF segment data from file
+                        // Copy ELF segment data from the embedded binary
                         if copy_size > 0 {
-                            core::ptr::copy(
-                                elf_addr.wrapping_add(copy_start),
+                            core::ptr::copy_nonoverlapping(
+                                elf_addr.add(copy_start),
                                 aligned_page_size_block_addr.raw() as *mut u8,
                                 copy_size,
                             );
                         }
 
-                        // Zero-initialize the remaining part of the page
+                        // Zero-initialize the remaining part of the page if p_memsz > p_filesz
                         if copy_size < PAGE_SIZE {
                             core::ptr::write_bytes(
                                 (aligned_page_size_block_addr.raw() as *mut u8).add(copy_size),
@@ -314,13 +332,13 @@ impl Guest {
                         }
                     }
 
-                    // update page flags
+                    // update page flags based on segment permissions
                     #[allow(clippy::match_same_arms)]
                     match prog_header.p_flags & 0b111 {
-                        // update page flags to `[Dirty, Accessed, Read, User, Valid]`
+                        // R--
                         0b100 => page_table::sv39x4::update_page_flags(
                             guest_physical_addr,
-                            [Dirty, Accessed, Read, User, Valid]
+                            [Dirty, Accessed, Read, User, Valid] // No Exec, No Write
                                 .iter()
                                 .fold(0, |pte_f, f| (pte_f | *f as u8)),
                         )
@@ -332,12 +350,25 @@ impl Guest {
                         // FIXME: Add Exec permission (RW -> RWX)
                         0b110 => (), // no update
                         0b111 => (), // no update
-                        _ => panic!("unsupported flags"),
+                        _ => panic!("unsupported ELF segment flags"),
                     }
                 }
             }
         }
 
-        self.dram_base()
+        // The virtual entry point.
+        let virt_entry = guest_elf.ehdr.e_entry;
+        // The virtual address of the first loadable segment is the virtual base.
+        let virt_base = guest_elf
+            .segments()
+            .unwrap()
+            .iter()
+            .find(|p| p.p_type == PT_LOAD && p.p_memsz > 0)
+            .map(|p| p.p_vaddr)
+            .expect("No loadable segment found in ELF");
+
+        // Calculate the physical entry point: physical_base + (virtual_entry - virtual_base)
+        let phys_entry = self.dram_base().raw() as u64 + (virt_entry - virt_base);
+        GuestPhysicalAddress(phys_entry as usize)
     }
 }

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -45,9 +45,10 @@ impl Guest {
         guest_dtb: &'static [u8],
         guest_initrd: &'static [u8],
     ) -> Self {
-        // calculate guest memory region
+        // Calculate guest memory region.
         let guest_memory_begin: GuestPhysicalAddress =
             guest_memory::DRAM_BASE + (hart_id + 1) * guest_memory::DRAM_SIZE_PER_GUEST;
+
         let memory_region =
             guest_memory_begin..guest_memory_begin + guest_memory::DRAM_SIZE_PER_GUEST;
 
@@ -64,7 +65,7 @@ impl Guest {
         let dtb_addr = Self::load_guest_dtb(hart_id, page_table_addr, guest_dtb);
 
         // laod guest initrd
-        Self::load_initrd(hart_id, guest_initrd);
+        Self::load_initrd(hart_id, guest_initrd, &memory_region);
 
         Guest {
             hart_id,
@@ -109,40 +110,45 @@ impl Guest {
     }
 
     /// Load guest's initrd
-    fn load_initrd(hart_id: usize, guest_initrd: &'static [u8]) {
+    fn load_initrd(
+        hart_id: usize,
+        guest_initrd: &'static [u8],
+        memory_region: &Range<GuestPhysicalAddress>,
+    ) {
         if guest_initrd.is_empty() {
             return;
         }
 
         let aligned_initrd_size = guest_initrd.len().div_ceil(PAGE_SIZE) * PAGE_SIZE;
-        let guest_base =
-            guest_memory::DRAM_BASE + guest_memory::DRAM_SIZE_PER_GUEST * (hart_id + 1);
-        let initrd_start = guest_base + guest_memory::DRAM_SIZE_PER_GUEST - aligned_initrd_size;
+        let initrd_start = memory_region.end - aligned_initrd_size;
 
         crate::println!(
-            "initrd (GPA): {:#x}..{:#x}",
+            "initrd (hart {}): Mapping {:#x} bytes to GPA [{:#x} - {:#x}]",
+            hart_id,
+            guest_initrd.len(),
             initrd_start.raw(),
-            initrd_start.raw() + guest_initrd.len()
+            initrd_start.raw() + guest_initrd.len(),
         );
 
-        for offset in (0..aligned_initrd_size).step_by(PAGE_SIZE) {
+        for offset in (0..guest_initrd.len()).step_by(PAGE_SIZE) {
             let guest_physical_addr = initrd_start + offset;
 
-            // get page host physical address
             let page_size_block_addr: HostPhysicalAddress = if cfg!(feature = "identity_map") {
                 // identity map
                 HostPhysicalAddress(guest_physical_addr.raw())
             } else {
                 // translate allocated address (GPA) -> HPA
                 page_table::sv39x4::trans_addr(guest_physical_addr)
-                    .expect("failed to translate guest memory address in mapping")
+                    .expect("failed to translate guest memory address for initrd")
             };
 
+            let copy_size = (guest_initrd.len() - offset).min(PAGE_SIZE);
+
             unsafe {
-                core::ptr::copy(
-                    guest_initrd.as_ptr(),
+                core::ptr::copy_nonoverlapping(
+                    guest_initrd.as_ptr().add(offset),
                     page_size_block_addr.raw() as *mut u8,
-                    PAGE_SIZE,
+                    copy_size,
                 );
             }
         }

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -198,7 +198,7 @@ impl Guest {
         guest_elf: &ElfBytes<AnyEndian>,
         elf_addr: *const u8,
         guest_initrd: &'static [u8],
-    ) -> (GuestPhysicalAddress, GuestPhysicalAddress) {
+    ) -> GuestPhysicalAddress {
         /// Segment type `PT_LOAD`
         ///
         /// The array element specifies a loadable segment, described by `p_filesz` and `p_memsz`.
@@ -264,7 +264,7 @@ impl Guest {
             }
         }
 
-        (self.dram_base(), elf_end)
+        self.dram_base()
     }
 
     /// Load an elf to new allocated guest memory page.
@@ -290,7 +290,7 @@ impl Guest {
         guest_elf: &ElfBytes<AnyEndian>,
         elf_addr: *const u8,
         _guest_initrd: &'static [u8],
-    ) -> (GuestPhysicalAddress, GuestPhysicalAddress) {
+    ) -> GuestPhysicalAddress {
         /// Segment type `PT_LOAD`
         ///
         /// The array element specifies a loadable segment, described by `p_filesz` and `p_memsz`.
@@ -374,7 +374,7 @@ impl Guest {
             }
         }
 
-        (self.dram_base(), elf_end)
+        self.dram_base()
     }
 
     /// Allocate guest memory space from heap and create corresponding page table.
@@ -386,7 +386,8 @@ impl Guest {
     ) {
         use PteFlag::{Accessed, Dirty, Exec, Read, User, Valid, Write};
 
-        let all_pte_flags_are_set = &[Dirty, Accessed, Exec, Write, Read, User, Valid];
+        const all_pte_flags_are_set: &[PteFlag; 7] =
+            &[Dirty, Accessed, Exec, Write, Read, User, Valid];
 
         for guest_physical_addr in (region.start.raw()..region.end.raw()).step_by(PAGE_SIZE) {
             let guest_physical_addr = GuestPhysicalAddress(guest_physical_addr);
@@ -412,7 +413,8 @@ impl Guest {
     ) {
         use PteFlag::{Accessed, Dirty, Exec, Read, User, Valid, Write};
 
-        let all_pte_flags_are_set = &[Dirty, Accessed, Exec, Write, Read, User, Valid];
+        const all_pte_flags_are_set: &[PteFlag; 7] =
+            &[Dirty, Accessed, Exec, Write, Read, User, Valid];
 
         let aligned_initrd_size = guest_initrd.len().div_ceil(PAGE_SIZE) * PAGE_SIZE;
         let initrd_start = region.end - aligned_initrd_size;

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -42,6 +42,7 @@ impl Guest {
         hart_id: usize,
         root_page_table: &'static [PageTableEntry; FIRST_LV_PAGE_TABLE_LEN],
         guest_dtb: &'static [u8],
+        guest_initrd: &'static [u8],
     ) -> Self {
         // calculate guest memory region
         let guest_memory_begin: GuestPhysicalAddress =
@@ -58,6 +59,9 @@ impl Guest {
         // load guest dtb to memory
         let dtb_addr = Self::load_guest_dtb(hart_id, page_table_addr, guest_dtb);
 
+        // laod guest initrd
+        Self::load_initrd(hart_id, guest_initrd);
+
         Guest {
             hart_id,
             page_table_addr: HostPhysicalAddress(root_page_table.as_ptr() as usize),
@@ -65,6 +69,45 @@ impl Guest {
             stack_top_addr,
             memory_region,
             context: Context::new(stack_top_addr - core::mem::size_of::<ContextData>()),
+        }
+    }
+
+    pub fn load_initrd(hart_id: usize, guest_initrd: &'static [u8]) {
+        if guest_initrd.is_empty() {
+            return;
+        }
+
+        let aligned_initrd_size = guest_initrd.len().div_ceil(PAGE_SIZE) * PAGE_SIZE;
+        let guest_base =
+            guest_memory::DRAM_BASE + guest_memory::DRAM_SIZE_PER_GUEST * (hart_id + 1);
+        let initrd_start = guest_base + guest_memory::DRAM_SIZE_PER_GUEST - aligned_initrd_size;
+
+        crate::println!(
+            "initrd (GPA): {:#x}..{:#x}",
+            initrd_start.raw(),
+            initrd_start.raw() + guest_initrd.len()
+        );
+
+        for offset in (0..aligned_initrd_size).step_by(PAGE_SIZE) {
+            let guest_physical_addr = initrd_start + offset;
+
+            // get page host physical address
+            let aligned_page_size_block_addr: HostPhysicalAddress =
+                if cfg!(feature = "identity_map") {
+                    // identity map
+                    HostPhysicalAddress(guest_physical_addr.raw())
+                } else {
+                    // allocate memory from heap
+                    PageBlock::alloc()
+                };
+
+            unsafe {
+                core::ptr::copy(
+                    guest_initrd.as_ptr(),
+                    aligned_page_size_block_addr.raw() as *mut u8,
+                    PAGE_SIZE,
+                );
+            }
         }
     }
 

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -83,8 +83,7 @@ impl Guest {
     ) {
         use PteFlag::{Accessed, Dirty, Exec, Read, User, Valid, Write};
 
-        const ALL_PTE_FLAGS_ARE_SET: &[PteFlag; 7] =
-            &[Dirty, Accessed, Exec, Write, Read, User, Valid];
+        const G_STAGE_PTE_FLAGS: &[PteFlag; 7] = &[Dirty, Accessed, Read, Write, Exec, User, Valid];
 
         for guest_physical_addr in (region.start.raw()..region.end.raw()).step_by(PAGE_SIZE) {
             let guest_physical_addr = GuestPhysicalAddress(guest_physical_addr);
@@ -103,7 +102,7 @@ impl Guest {
                 &[MemoryMap::new(
                     guest_physical_addr..guest_physical_addr + PAGE_SIZE,
                     aligned_page_size_block_addr..aligned_page_size_block_addr + PAGE_SIZE,
-                    ALL_PTE_FLAGS_ARE_SET,
+                    G_STAGE_PTE_FLAGS,
                 )],
             );
         }

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -172,7 +172,6 @@ impl Guest {
         &self,
         guest_elf: &ElfBytes<AnyEndian>,
         elf_addr: *const u8,
-        _guest_initrd: &'static [u8],
     ) -> GuestPhysicalAddress {
         use PteFlag::{Accessed, Dirty, Read, User, Valid};
 

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -317,7 +317,12 @@ impl Guest {
             let guest_physical_addr = GuestPhysicalAddress(guest_physical_addr);
 
             // allocate memory from heap
-            let aligned_page_size_block_addr = PageBlock::alloc();
+            let aligned_page_size_block_addr: HostPhysicalAddress =
+                if cfg!(feature = "identity_map") {
+                    HostPhysicalAddress(guest_physical_addr.raw())
+                } else {
+                    PageBlock::alloc()
+                };
 
             // create memory mapping
             page_table::sv39x4::generate_page_table(

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -155,8 +155,6 @@ impl Guest {
     }
 
     /// Load guest device tree and create corresponding page table
-    ///
-    /// Guest device tree will be placed start of guest memory region.
     fn load_guest_dtb(
         hart_id: usize,
         page_table_addr: HostPhysicalAddress,
@@ -166,7 +164,7 @@ impl Guest {
 
         assert!(guest_dtb.len() < guest_memory::GUEST_DTB_REGION_SIZE);
 
-        // guest device tree is loaded at end of guest memory region.
+        // Guest device tree is loaded at a fixed offset from DRAM_BASE.
         let guest_dtb_addr =
             guest_memory::DRAM_BASE + hart_id * guest_memory::GUEST_DTB_REGION_SIZE;
         let aligned_dtb_size = guest_dtb.len().div_ceil(PAGE_SIZE) * PAGE_SIZE;
@@ -174,23 +172,16 @@ impl Guest {
         for offset in (0..aligned_dtb_size).step_by(PAGE_SIZE) {
             let guest_physical_addr = guest_dtb_addr + offset;
 
-            // get page address
-            let aligned_page_size_block_addr: HostPhysicalAddress =
-                if cfg!(feature = "identity_map") {
-                    // identity map
-                    HostPhysicalAddress(guest_physical_addr.raw())
-                } else {
-                    // allocate memory from heap
-                    PageBlock::alloc()
-                };
-
-            // copy elf segment to new heap block
-            unsafe {
-                core::ptr::copy(
-                    guest_dtb.as_ptr().byte_add(offset),
-                    aligned_page_size_block_addr.raw() as *mut u8,
-                    PAGE_SIZE,
-                );
+            let aligned_page_size_block_addr: HostPhysicalAddress = PageBlock::alloc();
+            let copy_size = (guest_dtb.len() - offset).min(PAGE_SIZE);
+            if copy_size > 0 {
+                unsafe {
+                    core::ptr::copy_nonoverlapping(
+                        guest_dtb.as_ptr().add(offset),
+                        aligned_page_size_block_addr.raw() as *mut u8,
+                        copy_size,
+                    );
+                }
             }
 
             // create memory mapping

--- a/hikami_core/src/memmap/page_table.rs
+++ b/hikami_core/src/memmap/page_table.rs
@@ -95,6 +95,12 @@ impl PageTableEntry {
         Self((ppn << 10) | u64::from(flags))
     }
 
+    /// Set PTE flag.
+    fn set_flags(&mut self, flags: u8) {
+        let ppn_mask = 0xFFF_FFFF_FFFF_FC00; // 10 bit
+        self.0 = (self.0 & ppn_mask) | u64::from(flags);
+    }
+
     /// Is leaf page table entry
     fn is_leaf(self) -> bool {
         let pte_r = (self.0 >> 1) & 0x1;

--- a/hikami_core/src/memmap/page_table/sv39x4.rs
+++ b/hikami_core/src/memmap/page_table/sv39x4.rs
@@ -260,3 +260,68 @@ pub fn trans_addr(
         "[sv39x4] cannnot reach to leaf entry",
     ))
 }
+
+/// Updates the permission flags for a specific Guest Physical Address (GPA)
+/// in the G-stage page table.
+/// This function walks the page table to find the leaf PTE corresponding to the GPA
+/// and overwrites its flags.
+///
+/// # Arguments
+/// * `root_table_start_addr` - The Host Physical Address (HPA) of the root page table.
+/// * `gpa` - The Guest Physical Address (GPA) of the page whose flags need to be updated.
+/// * `new_flags` - The new set of permission flags to apply to the PTE.
+///
+/// # Errors
+/// Returns an error if the page table walk encounters an invalid entry or
+/// does not resolve to a leaf PTE for the given address.
+#[allow(clippy::cast_possible_truncation)]
+pub fn update_page_flags(
+    gpa: GuestPhysicalAddress,
+    new_flags: u8,
+) -> Result<(), (TransAddrError, &'static str)> {
+    let hgatp = hgatp::read();
+    let mut page_table_addr = PageTableAddress(hgatp.ppn() << 12);
+
+    // Iterate through the page table levels from top to bottom (L2 -> L1 -> L0).
+    for level in [
+        PageTableLevel::Lv1GB,
+        PageTableLevel::Lv2MB,
+        PageTableLevel::Lv4KB,
+    ] {
+        // Get the current level's page table. The root table has a different size.
+        let page_table = match level {
+            PageTableLevel::Lv1GB => unsafe {
+                from_raw_parts_mut(page_table_addr.to_pte_ptr(), FIRST_LV_PAGE_TABLE_LEN)
+            },
+            _ => unsafe { from_raw_parts_mut(page_table_addr.to_pte_ptr(), PAGE_TABLE_LEN) },
+        };
+
+        // Get the Page Table Entry (PTE) for the current level's VPN.
+        let vpn = gpa.vpn(level as usize);
+        let pte = &mut page_table[vpn];
+
+        if pte.is_invalid() {
+            return Err((
+                TransAddrError::InvalidEntry,
+                "Update failed: encountered an invalid PTE during page table walk",
+            ));
+        }
+
+        // If it's a leaf PTE (a superpage or a final 4KB page),
+        // update its flags and terminate the walk.
+        if pte.is_leaf() {
+            pte.set_flags(new_flags);
+            return Ok(());
+        }
+
+        // If not a leaf, it must point to the next level table.
+        // Calculate the address of the next level page table.
+        page_table_addr = PageTableAddress(pte.entire_ppn() as usize * PAGE_SIZE);
+    }
+
+    // If the loop completes without finding a leaf PTE, it's an error.
+    Err((
+        TransAddrError::NoLeafEntry,
+        "Update failed: page table walk did not end on a leaf PTE",
+    ))
+}

--- a/hikami_core/src/memmap/page_table/sv48.rs
+++ b/hikami_core/src/memmap/page_table/sv48.rs
@@ -1,8 +1,8 @@
 //! Sv48: Page-Based 48-bit Virtual-Memory System
 
 use super::{
-    constants::{PAGE_SIZE, PAGE_TABLE_LEN},
     PageTableAddress, PageTableEntry, PageTableLevel, TransAddrError,
+    constants::{PAGE_SIZE, PAGE_TABLE_LEN},
 };
 use crate::h_extension::csrs::vsatp;
 use crate::memmap::{GuestPhysicalAddress, GuestVirtualAddress};

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -128,13 +128,13 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
         }
     };
 
-    // initialize hypervisor data
-    let mut hypervisor_data = unsafe { HYPERVISOR_DATA.lock() };
-    hypervisor_data.get_or_init(|| HypervisorData::new(hart_id, device_tree));
-
     // enable two-level address translation
     hgatp::set(hgatp::Mode::Sv39x4, 0, root_page_table_addr.raw() >> 12);
     hfence_gvma_all();
+
+    // initialize hypervisor data
+    let mut hypervisor_data = unsafe { HYPERVISOR_DATA.lock() };
+    hypervisor_data.get_or_init(|| HypervisorData::new(hart_id, device_tree));
 
     // load guest elf `from GUEST_KERNEL`
     let guest_elf = unsafe {
@@ -144,10 +144,6 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
         ))
         .unwrap()
     };
-
-    // allocate page tables to all remain guest memory region
-    let guest_memory_region = new_guest.memory_region().clone();
-    new_guest.allocate_memory_region(guest_memory_region);
 
     // load guest image
     let guest_entry_point = new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr());

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -145,11 +145,9 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
         .unwrap()
     };
 
-    if cfg!(not(feature = "identity_map")) {
-        // allocate page tables to all remain guest memory region
-        let guest_memory_region = new_guest.memory_region().clone();
-        new_guest.allocate_memory_region(guest_memory_region);
-    }
+    // allocate page tables to all remain guest memory region
+    let guest_memory_region = new_guest.memory_region().clone();
+    new_guest.allocate_memory_region(guest_memory_region);
 
     // load guest image
     let guest_entry_point = new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr());

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -142,17 +142,10 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
         .unwrap()
     };
 
-    if cfg!(feature = "identity_map") {
-        let guest_memory_start =
-            guest_memory::DRAM_BASE + (hart_id + 1) * guest_memory::DRAM_SIZE_PER_GUEST;
-        new_guest.allocate_memory_region(
-            guest_memory_start..guest_memory_start + guest_memory::DRAM_SIZE_PER_GUEST,
-            &GUEST_INITRD,
-        );
-    } else {
+    if cfg!(not(feature = "identity_map")) {
         // allocate page tables to all remain guest memory region
         let guest_memory_region = new_guest.memory_region().clone();
-        new_guest.allocate_memory_region(guest_memory_region, &GUEST_INITRD);
+        new_guest.allocate_memory_region(guest_memory_region);
     }
 
     // load guest image

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -116,9 +116,13 @@ pub extern "C" fn hstart(hart_id: usize, dtb_addr: usize) -> ! {
 /// * Parse DTB
 /// * Setup page table
 fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
+    // enable two-level address translation
+    let root_page_table_addr = HostPhysicalAddress(ROOT_PAGE_TABLE.as_ptr() as usize);
+    hgatp::set(hgatp::Mode::Sv39x4, 0, root_page_table_addr.raw() >> 12);
+    hfence_gvma_all();
+
     // create new guest data
     let new_guest = Guest::new(hart_id, &ROOT_PAGE_TABLE, &GUEST_DTB, &GUEST_INITRD);
-    let root_page_table_addr = HostPhysicalAddress(ROOT_PAGE_TABLE.as_ptr() as usize);
 
     // parse device tree
     let device_tree = unsafe {
@@ -127,10 +131,6 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
             Err(e) => panic!("{}", e),
         }
     };
-
-    // enable two-level address translation
-    hgatp::set(hgatp::Mode::Sv39x4, 0, root_page_table_addr.raw() >> 12);
-    hfence_gvma_all();
 
     // initialize hypervisor data
     let mut hypervisor_data = unsafe { HYPERVISOR_DATA.lock() };

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -132,6 +132,10 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
     let mut hypervisor_data = unsafe { HYPERVISOR_DATA.lock() };
     hypervisor_data.get_or_init(|| HypervisorData::new(hart_id, device_tree));
 
+    // enable two-level address translation
+    hgatp::set(hgatp::Mode::Sv39x4, 0, root_page_table_addr.raw() >> 12);
+    hfence_gvma_all();
+
     // load guest elf `from GUEST_KERNEL`
     let guest_elf = unsafe {
         ElfBytes::<AnyEndian>::minimal_parse(core::slice::from_raw_parts(
@@ -156,10 +160,6 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
         .unwrap()
         .devices()
         .device_mapping_g_stage(root_page_table_addr);
-
-    // enable two-level address translation
-    hgatp::set(hgatp::Mode::Sv39x4, 0, root_page_table_addr.raw() >> 12);
-    hfence_gvma_all();
 
     // initialize IOMMU
     hypervisor_data

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -142,10 +142,6 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
         .unwrap()
     };
 
-    // load guest image
-    let (guest_entry_point, elf_end_addr) =
-        new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr(), &GUEST_INITRD);
-
     if cfg!(feature = "identity_map") {
         let guest_memory_start =
             guest_memory::DRAM_BASE + (hart_id + 1) * guest_memory::DRAM_SIZE_PER_GUEST;
@@ -155,9 +151,13 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
         );
     } else {
         // allocate page tables to all remain guest memory region
-        let guest_memory_end = new_guest.memory_region().end;
-        new_guest.allocate_memory_region(elf_end_addr..guest_memory_end, &GUEST_INITRD);
+        let guest_memory_region = new_guest.memory_region().clone();
+        new_guest.allocate_memory_region(guest_memory_region, &GUEST_INITRD);
     }
+
+    // load guest image
+    let guest_entry_point =
+        new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr(), &GUEST_INITRD);
 
     // set device memory map
     hypervisor_data

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -5,13 +5,12 @@ use crate::{ALLOCATOR, GUEST_DTB, GUEST_INITRD, GUEST_KERNEL};
 use hikami_core::guest::Guest;
 use hikami_core::guest::context::ContextData;
 use hikami_core::h_extension::csrs::{
-    VsInterruptKind, hcounteren, hedeleg, hedeleg::ExceptionKind, henvcfg, hgatp, hideleg, hie,
-    hstatus, hvip, vsatp,
+    VsInterruptKind, hcounteren, hedeleg, hedeleg::ExceptionKind, hgatp, hideleg, hie, hstatus,
+    hvip, vsatp,
 };
 use hikami_core::h_extension::instruction::hfence_gvma_all;
 use hikami_core::memmap::{
-    GuestPhysicalAddress, HostPhysicalAddress, constant::guest_memory,
-    page_table::sv39x4::ROOT_PAGE_TABLE,
+    GuestPhysicalAddress, HostPhysicalAddress, page_table::sv39x4::ROOT_PAGE_TABLE,
 };
 use hikami_core::{_hv_heap_size, _start_heap};
 use hikami_core::{HYPERVISOR_DATA, HypervisorData};
@@ -149,8 +148,7 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
     }
 
     // load guest image
-    let guest_entry_point =
-        new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr(), &GUEST_INITRD);
+    let guest_entry_point = new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr());
 
     // set device memory map
     hypervisor_data

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -117,7 +117,7 @@ pub extern "C" fn hstart(hart_id: usize, dtb_addr: usize) -> ! {
 /// * Setup page table
 fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
     // create new guest data
-    let new_guest = Guest::new(hart_id, &ROOT_PAGE_TABLE, &GUEST_DTB);
+    let new_guest = Guest::new(hart_id, &ROOT_PAGE_TABLE, &GUEST_DTB, &GUEST_INITRD);
     let root_page_table_addr = HostPhysicalAddress(ROOT_PAGE_TABLE.as_ptr() as usize);
 
     // parse device tree

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -146,7 +146,7 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
     };
 
     // load guest image
-    let guest_entry_point = new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr());
+    let guest_entry_point = unsafe { new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr()) };
 
     // set device memory map
     hypervisor_data

--- a/src/trap/exception/instruction_handler.rs
+++ b/src/trap/exception/instruction_handler.rs
@@ -17,7 +17,15 @@ extension_manager::import_global_variables!();
 pub fn illegal_instruction() {
     let fault_inst_value = stval::read();
     let fault_inst = Instruction::try_from(fault_inst_value).unwrap_or_else(|_| {
-        panic!("decoding load fault instruction failed: fault inst value: {fault_inst_value:#x} at {:#x}", sepc::read());
+        use hikami_core::memmap::GuestVirtualAddress;
+        let gva = GuestVirtualAddress(sepc::read());
+        let gpa = hikami_core::memmap::page_table::vs_stage_trans_addr(gva).unwrap();
+        let hpa = hikami_core::memmap::page_table::g_stage_trans_addr(gpa).unwrap();
+
+        panic!(
+            "decoding load fault instruction failed: fault inst value: {fault_inst_value:#x} at {:#x}(GPA: {:#x}, HPA: {:#x})",
+            sepc::read(), gpa.raw(), hpa.raw()
+        );
     });
 
     // emulate the instruction
@@ -29,7 +37,15 @@ pub fn illegal_instruction() {
 pub fn virtual_instruction() {
     let fault_inst_value = stval::read();
     let fault_inst = Instruction::try_from(fault_inst_value).unwrap_or_else(|_| {
-        panic!("decoding load fault instruction failed: fault inst value: {fault_inst_value:#x} at {:#x}", sepc::read());
+        use hikami_core::memmap::GuestVirtualAddress;
+        let gva = GuestVirtualAddress(sepc::read());
+        let gpa = hikami_core::memmap::page_table::vs_stage_trans_addr(gva).unwrap();
+        let hpa = hikami_core::memmap::page_table::g_stage_trans_addr(gpa).unwrap();
+
+        panic!(
+            "decoding load fault instruction failed: fault inst value: {fault_inst_value:#x} at {:#x}(GPA: {:#x}, HPA: {:#x})",
+            sepc::read(), gpa.raw(), hpa.raw()
+        );
     });
 
     // emulate CSR set

--- a/src/trap/exception/instruction_handler.rs
+++ b/src/trap/exception/instruction_handler.rs
@@ -14,6 +14,7 @@ extension_manager::import_global_variables!();
 
 /// Trap `Illegal instruction` exception.
 #[inline]
+#[allow(clippy::similar_names)]
 pub fn illegal_instruction() {
     let fault_inst_value = stval::read();
     let fault_inst = Instruction::try_from(fault_inst_value).unwrap_or_else(|_| {
@@ -34,6 +35,7 @@ pub fn illegal_instruction() {
 
 /// Trap `Virtual instruction` exception.
 #[inline]
+#[allow(clippy::similar_names)]
 pub fn virtual_instruction() {
     let fault_inst_value = stval::read();
     let fault_inst = Instruction::try_from(fault_inst_value).unwrap_or_else(|_| {


### PR DESCRIPTION
Change a memory mapping method to map whole guest memory space before loading a guest kernel image.
Previously, the hypervisor only maps elf segment region, occasionally occurring page fault.
This changes will fix this problem.