### PR TITLE
Fix the device mapping method

### DIFF
--- a/guest_image/qemu.dts
+++ b/guest_image/qemu.dts
@@ -1,0 +1,213 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x02>;
+	#size-cells = <0x02>;
+	compatible = "riscv-virtio";
+	model = "riscv-virtio,qemu";
+
+	poweroff {
+		value = <0x5555>;
+		offset = <0x00>;
+		regmap = <0x04>;
+		compatible = "syscon-poweroff";
+	};
+
+	reboot {
+		value = <0x7777>;
+		offset = <0x00>;
+		regmap = <0x04>;
+		compatible = "syscon-reboot";
+	};
+
+	platform-bus@4000000 {
+		interrupt-parent = <0x03>;
+		ranges = <0x00 0x00 0x4000000 0x2000000>;
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		compatible = "qemu,platform", "simple-bus";
+	};
+
+	memory@90000000 {
+		device_type = "memory";
+		reg = <0x00 0x90000000 0x00 0x20000000>;
+	};
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+		timebase-frequency = <0x989680>;
+
+		cpu@0 {
+			phandle = <0x01>;
+			device_type = "cpu";
+			reg = <0x00>;
+			status = "okay";
+			compatible = "riscv";
+			riscv,cbop-block-size = <0x40>;
+			riscv,cboz-block-size = <0x40>;
+			riscv,cbom-block-size = <0x40>;
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "h", "zic64b", "zicbom", "zicbop", "zicboz", "ziccamoa", "ziccif", "zicclsm", "ziccrse", "zicfiss", "zicntr", "zicsr", "zifencei", "zihintntl", "zihintpause", "zihpm", "zmmul", "za64rs", "zaamo", "zalrsc", "zawrs", "zfa", "zca", "zcd", "zba", "zbb", "zbc", "zbs", "ssccptr", "sscounterenw", "sstc", "sstvala", "sstvecd", "svadu";
+			riscv,isa-base = "rv64i";
+			riscv,isa = "rv64imafdch_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_zicclsm_ziccrse_zicfiss_zicntr_zicsr_zifencei_zihintntl_zihintpause_zihpm_zmmul_za64rs_zaamo_zalrsc_zawrs_zfa_zca_zcd_zba_zbb_zbc_zbs_ssccptr_sscounterenw_sstc_sstvala_sstvecd_svadu";
+			mmu-type = "riscv,sv57";
+
+			interrupt-controller {
+				#interrupt-cells = <0x01>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+				phandle = <0x02>;
+			};
+		};
+
+		cpu-map {
+
+			cluster0 {
+
+				core0 {
+					cpu = <0x01>;
+				};
+			};
+		};
+	};
+
+	pmu {
+		riscv,event-to-mhpmcounters = <0x01 0x01 0x7fff9 0x02 0x02 0x7fffc 0x10019 0x10019 0x7fff8 0x1001b 0x1001b 0x7fff8 0x10021 0x10021 0x7fff8>;
+		compatible = "riscv,pmu";
+	};
+
+	fw-cfg@10100000 {
+		dma-coherent;
+		reg = <0x00 0x10100000 0x00 0x18>;
+		compatible = "qemu,fw-cfg-mmio";
+	};
+
+	flash@20000000 {
+		bank-width = <0x04>;
+		reg = <0x00 0x20000000 0x00 0x2000000 0x00 0x22000000 0x00 0x2000000>;
+		compatible = "cfi-flash";
+	};
+
+	chosen {
+		bootargs = "root=/dev/sda locale.LANG=en_US.UTF-8";
+		stdout-path = "/soc/serial@10000000";
+		rng-seed = <0x9775b34d 0xe39158f2 0x3e9d10b1 0x73692dfd 0x13c15814 0xa4ad203f 0x8b0d62f7 0x6bf8a79d>;
+	};
+
+	soc {
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		compatible = "simple-bus";
+		ranges;
+
+		rtc@101000 {
+			interrupts = <0x0b>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x101000 0x00 0x1000>;
+			compatible = "google,goldfish-rtc";
+		};
+
+		serial@10000000 {
+			interrupts = <0x0a>;
+			interrupt-parent = <0x03>;
+			clock-frequency = "", "8@";
+			reg = <0x00 0x10000000 0x00 0x100>;
+			compatible = "ns16550a";
+		};
+
+		test@100000 {
+			phandle = <0x04>;
+			reg = <0x00 0x100000 0x00 0x1000>;
+			compatible = "sifive,test1", "sifive,test0", "syscon";
+		};
+
+		virtio_mmio@10008000 {
+			interrupts = <0x08>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10008000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10007000 {
+			interrupts = <0x07>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10007000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10006000 {
+			interrupts = <0x06>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10006000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10005000 {
+			interrupts = <0x05>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10005000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10004000 {
+			interrupts = <0x04>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10004000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10003000 {
+			interrupts = <0x03>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10003000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10002000 {
+			interrupts = <0x02>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10002000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10001000 {
+			interrupts = <0x01>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10001000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		plic@c000000 {
+			phandle = <0x03>;
+			riscv,ndev = <0x5f>;
+			reg = <0x00 0xc000000 0x00 0x600000>;
+			interrupts-extended = <0x02 0x0b 0x02 0x09>;
+			interrupt-controller;
+			compatible = "sifive,plic-1.0.0", "riscv,plic0";
+			#address-cells = <0x00>;
+			#interrupt-cells = <0x01>;
+		};
+
+		clint@2000000 {
+			interrupts-extended = <0x02 0x03 0x02 0x07>;
+			reg = <0x00 0x2000000 0x00 0x10000>;
+			compatible = "sifive,clint0", "riscv,clint0";
+		};
+
+		pci@30000000 {
+			interrupt-map-mask = <0x1800 0x00 0x00 0x07>;
+			interrupt-map = <0x00 0x00 0x00 0x01 0x03 0x20 0x00 0x00 0x00 0x02 0x03 0x21 0x00 0x00 0x00 0x03 0x03 0x22 0x00 0x00 0x00 0x04 0x03 0x23 0x800 0x00 0x00 0x01 0x03 0x21 0x800 0x00 0x00 0x02 0x03 0x22 0x800 0x00 0x00 0x03 0x03 0x23 0x800 0x00 0x00 0x04 0x03 0x20 0x1000 0x00 0x00 0x01 0x03 0x22 0x1000 0x00 0x00 0x02 0x03 0x23 0x1000 0x00 0x00 0x03 0x03 0x20 0x1000 0x00 0x00 0x04 0x03 0x21 0x1800 0x00 0x00 0x01 0x03 0x23 0x1800 0x00 0x00 0x02 0x03 0x20 0x1800 0x00 0x00 0x03 0x03 0x21 0x1800 0x00 0x00 0x04 0x03 0x22>;
+			ranges = <0x1000000 0x00 0x00 0x00 0x3000000 0x00 0x10000 0x2000000 0x00 0x40000000 0x00 0x40000000 0x00 0x40000000 0x3000000 0x04 0x00 0x04 0x00 0x04 0x00>;
+			reg = <0x00 0x30000000 0x00 0x10000000>;
+			dma-coherent;
+			bus-range = <0x00 0xff>;
+			linux,pci-domain = <0x00>;
+			device_type = "pci";
+			compatible = "pci-host-ecam-generic";
+			#size-cells = <0x02>;
+			#interrupt-cells = <0x01>;
+			#address-cells = <0x03>;
+		};
+	};
+};
+

--- a/guest_image/qemu_iommu.dts
+++ b/guest_image/qemu_iommu.dts
@@ -1,0 +1,226 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x02>;
+	#size-cells = <0x02>;
+	compatible = "riscv-virtio";
+	model = "riscv-virtio,qemu";
+
+	poweroff {
+		value = <0x5555>;
+		offset = <0x00>;
+		regmap = <0x04>;
+		compatible = "syscon-poweroff";
+	};
+
+	reboot {
+		value = <0x7777>;
+		offset = <0x00>;
+		regmap = <0x04>;
+		compatible = "syscon-reboot";
+	};
+
+	platform-bus@4000000 {
+		interrupt-parent = <0x03>;
+		ranges = <0x00 0x00 0x4000000 0x2000000>;
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		compatible = "qemu,platform", "simple-bus";
+	};
+
+	memory@90000000 {
+		device_type = "memory";
+		reg = <0x00 0x90000000 0x00 0x20000000>;
+	};
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+		timebase-frequency = <0x989680>;
+
+		cpu@0 {
+			phandle = <0x01>;
+			device_type = "cpu";
+			reg = <0x00>;
+			status = "okay";
+			compatible = "riscv";
+			riscv,cbop-block-size = <0x40>;
+			riscv,cboz-block-size = <0x40>;
+			riscv,cbom-block-size = <0x40>;
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "h", "zic64b", "zicbom", "zicbop", "zicboz", "ziccamoa", "ziccif", "zicclsm", "ziccrse", "zicfiss", "zicntr", "zicsr", "zifencei", "zihintntl", "zihintpause", "zihpm", "zmmul", "za64rs", "zaamo", "zalrsc", "zawrs", "zfa", "zca", "zcd", "zba", "zbb", "zbc", "zbs", "ssccptr", "sscounterenw", "sstc", "sstvala", "sstvecd", "svadu";
+			riscv,isa-base = "rv64i";
+			riscv,isa = "rv64imafdch_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_zicclsm_ziccrse_zicfiss_zicntr_zicsr_zifencei_zihintntl_zihintpause_zihpm_zmmul_za64rs_zaamo_zalrsc_zawrs_zfa_zca_zcd_zba_zbb_zbc_zbs_ssccptr_sscounterenw_sstc_sstvala_sstvecd_svadu";
+			mmu-type = "riscv,sv57";
+
+			interrupt-controller {
+				#interrupt-cells = <0x01>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+				phandle = <0x02>;
+			};
+		};
+
+		cpu-map {
+
+			cluster0 {
+
+				core0 {
+					cpu = <0x01>;
+				};
+			};
+		};
+	};
+
+	pmu {
+		riscv,event-to-mhpmcounters = <0x01 0x01 0x7fff9 0x02 0x02 0x7fffc 0x10019 0x10019 0x7fff8 0x1001b 0x1001b 0x7fff8 0x10021 0x10021 0x7fff8>;
+		compatible = "riscv,pmu";
+	};
+
+	fw-cfg@10100000 {
+		dma-coherent;
+		reg = <0x00 0x10100000 0x00 0x18>;
+		compatible = "qemu,fw-cfg-mmio";
+	};
+
+	flash@20000000 {
+		bank-width = <0x04>;
+		reg = <0x00 0x20000000 0x00 0x2000000 0x00 0x22000000 0x00 0x2000000>;
+		compatible = "cfi-flash";
+	};
+
+	aliases {
+		serial0 = "/soc/serial@10000000";
+	};
+
+	chosen {
+		bootargs = "root=/dev/vda,rw,console=ttyS0";
+		stdout-path = "/soc/serial@10000000";
+		rng-seed = <0x768444e 0xccaf5142 0xb265ca8a 0x8552fc63 0xfc5730ab 0x3d3d2836 0x7178c610 0x34a28a17>;
+	};
+
+	soc {
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		compatible = "simple-bus";
+		ranges;
+
+		rtc@101000 {
+			interrupts = <0x0b>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x101000 0x00 0x1000>;
+			compatible = "google,goldfish-rtc";
+		};
+
+		serial@10000000 {
+			interrupts = <0x0a>;
+			interrupt-parent = <0x03>;
+			clock-frequency = "", "8@";
+			reg = <0x00 0x10000000 0x00 0x100>;
+			compatible = "ns16550a";
+		};
+
+		test@100000 {
+			phandle = <0x04>;
+			reg = <0x00 0x100000 0x00 0x1000>;
+			compatible = "sifive,test1", "sifive,test0", "syscon";
+		};
+
+		virtio_mmio@10008000 {
+			interrupts = <0x08>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10008000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10007000 {
+			interrupts = <0x07>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10007000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10006000 {
+			interrupts = <0x06>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10006000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10005000 {
+			interrupts = <0x05>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10005000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10004000 {
+			interrupts = <0x04>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10004000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10003000 {
+			interrupts = <0x03>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10003000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10002000 {
+			interrupts = <0x02>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10002000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10001000 {
+			interrupts = <0x01>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10001000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		plic@c000000 {
+			phandle = <0x03>;
+			riscv,ndev = <0x5f>;
+			reg = <0x00 0xc000000 0x00 0x600000>;
+			interrupts-extended = <0x02 0x0b 0x02 0x09>;
+			interrupt-controller;
+			compatible = "sifive,plic-1.0.0", "riscv,plic0";
+			#address-cells = <0x00>;
+			#interrupt-cells = <0x01>;
+		};
+
+		clint@2000000 {
+			interrupts-extended = <0x02 0x03 0x02 0x07>;
+			reg = <0x00 0x2000000 0x00 0x10000>;
+			compatible = "sifive,clint0", "riscv,clint0";
+		};
+
+		pci@30000000 {
+			interrupt-map-mask = <0x1800 0x00 0x00 0x07>;
+			interrupt-map = <0x00 0x00 0x00 0x01 0x03 0x20 0x00 0x00 0x00 0x02 0x03 0x21 0x00 0x00 0x00 0x03 0x03 0x22 0x00 0x00 0x00 0x04 0x03 0x23 0x800 0x00 0x00 0x01 0x03 0x21 0x800 0x00 0x00 0x02 0x03 0x22 0x800 0x00 0x00 0x03 0x03 0x23 0x800 0x00 0x00 0x04 0x03 0x20 0x1000 0x00 0x00 0x01 0x03 0x22 0x1000 0x00 0x00 0x02 0x03 0x23 0x1000 0x00 0x00 0x03 0x03 0x20 0x1000 0x00 0x00 0x04 0x03 0x21 0x1800 0x00 0x00 0x01 0x03 0x23 0x1800 0x00 0x00 0x02 0x03 0x20 0x1800 0x00 0x00 0x03 0x03 0x21 0x1800 0x00 0x00 0x04 0x03 0x22>;
+			ranges = <0x1000000 0x00 0x00 0x00 0x3000000 0x00 0x10000 0x2000000 0x00 0x40000000 0x00 0x40000000 0x00 0x40000000 0x3000000 0x04 0x00 0x04 0x00 0x04 0x00>;
+			reg = <0x00 0x30000000 0x00 0x10000000>;
+			dma-coherent;
+			bus-range = <0x00 0xff>;
+			linux,pci-domain = <0x00>;
+			device_type = "pci";
+			compatible = "pci-host-ecam-generic";
+			#size-cells = <0x02>;
+			#interrupt-cells = <0x01>;
+			#address-cells = <0x03>;
+			iommu-map = <0x00 0x8000 0x00 0x18 0x19 0x8000 0x19 0xffe7>;
+
+			iommu@18 {
+				reg = <0x1800 0x00 0x00 0x00 0x00>;
+				phandle = <0x8000>;
+				#iommu-cells = <0x01>;
+				compatible = "riscv,pci-iommu";
+			};
+		};
+	};
+};
+
+

--- a/hikami_core/src/device.rs
+++ b/hikami_core/src/device.rs
@@ -12,8 +12,10 @@ mod virtio;
 
 use crate::memmap::page_table::{PteFlag, constants::PAGE_SIZE, g_stage_trans_addr};
 use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap, page_table};
+
 use alloc::vec::Vec;
 use fdt::Fdt;
+use fdt::standard_nodes::MemoryRegion;
 
 /// Page table for device
 const PTE_FLAGS_FOR_DEVICE: [PteFlag; 6] = [
@@ -184,13 +186,38 @@ impl DmaHostBuffer {
 #[allow(clippy::module_name_repetitions)]
 pub trait MmioDevice {
     /// Create self instance.
+    /// * `root_page_table_addr` - root page table address
     /// * `device_tree` - struct Fdt
     /// * `compatibles` - compatible name list
-    fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self>
+    fn try_new(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        compatibles: &[&str],
+    ) -> Option<Self>
     where
         Self: Sized;
     /// Create page table
-    fn create_page_table(&self, root_page_table_addr: HostPhysicalAddress);
+    fn create_page_table(
+        root_page_table_addr: HostPhysicalAddress,
+        memory_regions: &[MemoryRegion],
+        node_name: &str,
+    ) {
+        for (i, map) in memory_regions.iter().enumerate() {
+            crate::println!(
+                "[Device Map] {}{} {:#x}..{:#x}",
+                node_name,
+                i,
+                map.starting_address as usize,
+                map.starting_address as usize + map.size.unwrap(),
+            )
+        }
+        let memory_maps: Vec<MemoryMap> = memory_regions
+            .iter()
+            .cloned()
+            .map(MemoryMap::from)
+            .collect();
+        page_table::sv39x4::generate_page_table(root_page_table_addr, &memory_maps);
+    }
     /// Return memory maps between physical to physical (identity map) for crate page table.
     fn memmap(&self) -> Vec<MemoryMap>;
 }
@@ -236,7 +263,7 @@ impl Devices {
     /// # Panics
     /// Panics if UART or PLIC or CLINT are not found in device tree.
     #[must_use]
-    pub fn new(device_tree: Fdt) -> Self {
+    pub fn new(root_page_table_addr: HostPhysicalAddress, device_tree: Fdt) -> Self {
         Devices {
             uart: uart::Uart::try_new(&device_tree, &["ns16550a", "synopsys,uart0"])
                 .expect("uart is not found in fdt"),

--- a/hikami_core/src/device.rs
+++ b/hikami_core/src/device.rs
@@ -254,12 +254,6 @@ impl Devices {
         }
     }
 
-    /// Identity map for devices.
-    pub fn device_mapping_g_stage(&self, page_table_start: HostPhysicalAddress) {
-        let memory_map = self.create_device_map();
-        page_table::sv39x4::generate_page_table(page_table_start, &memory_map);
-    }
-
     /// Return devices range to crate identity map.  
     /// It does not return `Plic` address to emulate it.
     fn create_device_map(&self) -> Vec<MemoryMap> {

--- a/hikami_core/src/device.rs
+++ b/hikami_core/src/device.rs
@@ -265,21 +265,46 @@ impl Devices {
     #[must_use]
     pub fn new(root_page_table_addr: HostPhysicalAddress, device_tree: Fdt) -> Self {
         Devices {
-            uart: uart::Uart::try_new(&device_tree, &["ns16550a", "synopsys,uart0"])
-                .expect("uart is not found in fdt"),
-            virtio_list: virtio::VirtIoList::new(&device_tree, "/soc/virtio_mmio"),
-            initrd: initrd::Initrd::try_new_from_node_path(&device_tree, "/chosen"),
-            plic: plic::Plic::try_new(&device_tree, &["riscv,plic0"])
+            uart: uart::Uart::try_new(
+                root_page_table_addr,
+                &device_tree,
+                &["ns16550a", "synopsys,uart0"],
+            )
+            .expect("uart is not found in fdt"),
+            virtio_list: virtio::VirtIoList::new(
+                root_page_table_addr,
+                &device_tree,
+                "/soc/virtio_mmio",
+            ),
+            initrd: initrd::Initrd::try_new_from_node_path(
+                root_page_table_addr,
+                &device_tree,
+                "/chosen",
+            ),
+            plic: plic::Plic::try_new(root_page_table_addr, &device_tree, &["riscv,plic0"])
                 .expect("plic is not found in fdt"),
             clint: clint::Clint::try_new(
+                root_page_table_addr,
                 &device_tree,
                 &["sifive,clint0", "riscv,clint0", "thead,c900-aclint-mtimer"],
             )
             .expect("clint is not found in fdt"),
-            rtc: rtc::Rtc::try_new(&device_tree, &["google,goldfish-rtc"]),
-            pci: pci::Pci::try_new(&device_tree, &["pci-host-ecam-generic"]),
-            axi_sdc: axi_sdc::Mmc::try_new(&device_tree, &["riscv,axi-sd-card-1.0"]),
-            sdhci: sdhci::Mmc::try_new(&device_tree, &["eswin,emmc-sdhci-5.1"]),
+            rtc: rtc::Rtc::try_new(root_page_table_addr, &device_tree, &["google,goldfish-rtc"]),
+            pci: pci::Pci::try_new(
+                root_page_table_addr,
+                &device_tree,
+                &["pci-host-ecam-generic"],
+            ),
+            axi_sdc: axi_sdc::Mmc::try_new(
+                root_page_table_addr,
+                &device_tree,
+                &["riscv,axi-sd-card-1.0"],
+            ),
+            sdhci: sdhci::Mmc::try_new(
+                root_page_table_addr,
+                &device_tree,
+                &["eswin,emmc-sdhci-5.1"],
+            ),
         }
     }
 

--- a/hikami_core/src/device.rs
+++ b/hikami_core/src/device.rs
@@ -189,6 +189,8 @@ pub trait MmioDevice {
     fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self>
     where
         Self: Sized;
+    /// Create page table
+    fn create_page_table(&self, root_page_table_addr: HostPhysicalAddress);
     /// Return memory maps between physical to physical (identity map) for crate page table.
     fn memmap(&self) -> Vec<MemoryMap>;
 }

--- a/hikami_core/src/device.rs
+++ b/hikami_core/src/device.rs
@@ -307,44 +307,4 @@ impl Devices {
             ),
         }
     }
-
-    /// Return devices range to crate identity map.  
-    /// It does not return `Plic` address to emulate it.
-    fn create_device_map(&self) -> Vec<MemoryMap> {
-        let mut device_mapping: Vec<MemoryMap> = self
-            .virtio_list
-            .iter()
-            .flat_map(|virt| virt.memmap())
-            .collect();
-
-        device_mapping.extend_from_slice(&self.uart.memmap());
-        device_mapping.extend_from_slice(&self.plic.memmap());
-        device_mapping.extend_from_slice(&self.clint.memmap());
-
-        if let Some(sdhci) = &self.sdhci {
-            device_mapping.extend_from_slice(&sdhci.memmap());
-        }
-        if let Some(rtc) = &self.rtc {
-            device_mapping.extend_from_slice(&rtc.memmap());
-        }
-        if let Some(initrd) = &self.initrd {
-            device_mapping.extend_from_slice(&initrd.memmap());
-        }
-
-        if let Some(pci) = &self.pci {
-            device_mapping.extend_from_slice(&pci.memmap());
-
-            if cfg!(feature = "identity_map") {
-                // mapping whole memory mapped register region of block divices.
-                device_mapping.extend_from_slice(pci.pci_memory_maps());
-            }
-        }
-        if cfg!(feature = "identity_map") {
-            if let Some(mmc) = &self.axi_sdc {
-                device_mapping.extend_from_slice(&mmc.memmap());
-            }
-        }
-
-        device_mapping
-    }
 }

--- a/hikami_core/src/device/axi_sdc.rs
+++ b/hikami_core/src/device/axi_sdc.rs
@@ -123,13 +123,21 @@ impl EmulateDevice for Mmc {
 }
 
 impl MmioDevice for Mmc {
-    fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let register_map_region = device_tree
-            .find_compatible(compatibles)?
-            .reg()
-            .unwrap()
-            .next()
-            .unwrap();
+    fn try_new(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        compatibles: &[&str],
+    ) -> Option<Self> {
+        let mmc_node = device_tree.find_compatible(compatibles)?;
+        let register_map_region = mmc_node.reg().unwrap().next().unwrap();
+
+        if cfg!(feature = "identity_map") {
+            Self::create_page_table(
+                root_page_table_addr,
+                &[register_map_region.into()],
+                mmc_node.name,
+            );
+        }
 
         Some(Mmc {
             register_map_region,

--- a/hikami_core/src/device/axi_sdc.rs
+++ b/hikami_core/src/device/axi_sdc.rs
@@ -132,11 +132,7 @@ impl MmioDevice for Mmc {
         let register_map_region = mmc_node.reg().unwrap().next().unwrap();
 
         if cfg!(feature = "identity_map") {
-            Self::create_page_table(
-                root_page_table_addr,
-                &[register_map_region.into()],
-                mmc_node.name,
-            );
+            Self::create_page_table(root_page_table_addr, &[register_map_region], mmc_node.name);
         }
 
         Some(Mmc {

--- a/hikami_core/src/device/clint.rs
+++ b/hikami_core/src/device/clint.rs
@@ -18,12 +18,15 @@ pub struct Clint {
 }
 
 impl MmioDevice for Clint {
-    fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let register_map_regions: Vec<MemoryRegion> = device_tree
-            .find_compatible(compatibles)?
-            .reg()
-            .unwrap()
-            .collect();
+    fn try_new(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        compatibles: &[&str],
+    ) -> Option<Self> {
+        let clint_node = device_tree.find_compatible(compatibles)?;
+        let register_map_regions: Vec<MemoryRegion> = clint_node.reg().unwrap().collect();
+
+        Self::create_page_table(root_page_table_addr, &register_map_regions, clint_node.name);
 
         Some(Clint {
             register_map_regions,

--- a/hikami_core/src/device/initrd.rs
+++ b/hikami_core/src/device/initrd.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::doc_markdown)]
 
 use super::MmioDevice;
-use crate::memmap::MemoryMap;
+use crate::memmap::{HostPhysicalAddress, MemoryMap};
 
 use alloc::vec;
 use alloc::vec::Vec;
@@ -18,7 +18,11 @@ pub struct Initrd {
 
 impl Initrd {
     /// Try to get Initrd data and return the `Initrd`.
-    pub fn try_new_from_node_path(device_tree: &Fdt, node_path: &str) -> Option<Self> {
+    pub fn try_new_from_node_path(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        node_path: &str,
+    ) -> Option<Self> {
         let start_prop = "linux,initrd-start";
         let end_prop = "linux,initrd-end";
         let node = device_tree.find_node(node_path).unwrap();
@@ -31,13 +35,14 @@ impl Initrd {
                 let start = u32::from_be_bytes(start[4..].try_into().unwrap()) as usize;
                 let end = node.property(end_prop).unwrap().value;
                 let end = u32::from_be_bytes(end[4..].try_into().unwrap()) as usize;
+                let memory_region = MemoryRegion {
+                    starting_address: start as *const u8,
+                    size: Some(end - start),
+                };
 
-                Some(Initrd {
-                    memory_map: MemoryRegion {
-                        starting_address: start as *const u8,
-                        size: Some(end - start),
-                    },
-                })
+                Self::create_page_table(root_page_table_addr, &[memory_region], node.name);
+
+                Some(Initrd { memory_region })
             }
             None => None,
         }
@@ -45,11 +50,15 @@ impl Initrd {
 }
 
 impl MmioDevice for Initrd {
-    fn try_new(_device_tree: &Fdt, _compatibles: &[&str]) -> Option<Self> {
+    fn try_new(
+        _root_page_table_addr: HostPhysicalAddress,
+        _device_tree: &Fdt,
+        _compatibles: &[&str],
+    ) -> Option<Self> {
         unreachable!("use Initrd::try_new_from_node_path instead")
     }
 
     fn memmap(&self) -> Vec<MemoryMap> {
-        vec![MemoryMap::from(self.memory_map)]
+        vec![MemoryMap::from(self.memory_region)]
     }
 }

--- a/hikami_core/src/device/initrd.rs
+++ b/hikami_core/src/device/initrd.rs
@@ -12,8 +12,8 @@ use fdt::{Fdt, standard_nodes::MemoryRegion};
 /// to be used as part of the Linux startup process.
 #[derive(Debug)]
 pub struct Initrd {
-    /// Memory maps
-    memory_map: MemoryRegion,
+    /// Memory mapped register region
+    memory_region: MemoryRegion,
 }
 
 impl Initrd {

--- a/hikami_core/src/device/pci.rs
+++ b/hikami_core/src/device/pci.rs
@@ -10,6 +10,7 @@ use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
 use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap, page_table};
 use config_register::{ConfigSpaceHeaderField, read_config_register};
 
+use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Range;
 use fdt::{Fdt, standard_nodes::MemoryRegion};
@@ -293,23 +294,22 @@ impl MmioDevice for Pci {
         // map Pci's register map
         Self::create_page_table(root_page_table_addr, &register_map_regions, pci_node.name);
 
-        let mut memory_maps = Vec::new();
-
-        // 32 bit reserved memory map
-        memory_maps.push(MemoryMap::new(
-            GuestPhysicalAddress(pci_addr_space.bit32_memory_space.start.raw())
-                ..GuestPhysicalAddress(pci_addr_space.bit32_memory_space.end.raw()),
-            pci_addr_space.bit32_memory_space.clone(),
-            &PTE_FLAGS_FOR_DEVICE,
-        ));
-
-        // 64 bit reserved memory map
-        memory_maps.push(MemoryMap::new(
-            GuestPhysicalAddress(pci_addr_space.bit64_memory_space.start.raw())
-                ..GuestPhysicalAddress(pci_addr_space.bit64_memory_space.end.raw()),
-            pci_addr_space.bit64_memory_space.clone(),
-            &PTE_FLAGS_FOR_DEVICE,
-        ));
+        let memory_maps = vec![
+            // 32 bit reserved memory map
+            MemoryMap::new(
+                GuestPhysicalAddress(pci_addr_space.bit32_memory_space.start.raw())
+                    ..GuestPhysicalAddress(pci_addr_space.bit32_memory_space.end.raw()),
+                pci_addr_space.bit32_memory_space.clone(),
+                &PTE_FLAGS_FOR_DEVICE,
+            ),
+            // 64 bit reserved memory map
+            MemoryMap::new(
+                GuestPhysicalAddress(pci_addr_space.bit64_memory_space.start.raw())
+                    ..GuestPhysicalAddress(pci_addr_space.bit64_memory_space.end.raw()),
+                pci_addr_space.bit64_memory_space.clone(),
+                &PTE_FLAGS_FOR_DEVICE,
+            ),
+        ];
 
         // map PCI device's register map field
         if cfg!(feature = "identity_map") {

--- a/hikami_core/src/device/pci.rs
+++ b/hikami_core/src/device/pci.rs
@@ -7,7 +7,7 @@ mod sata;
 pub mod config_register;
 
 use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
-use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
+use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap, page_table};
 use config_register::{ConfigSpaceHeaderField, read_config_register};
 
 use alloc::vec::Vec;
@@ -296,9 +296,13 @@ impl MmioDevice for Pci {
         // assume that pci register contains first region.
         let base_address = HostPhysicalAddress(register_map_regions[0].starting_address as usize);
 
-        let mut memory_maps = Vec::new();
         let pci_addr_space = PciAddressSpace::new(device_tree, compatibles);
         let pci_devices = PciDevices::new(device_tree, base_address, &pci_addr_space);
+
+        // map Pci's register map
+        Self::create_page_table(root_page_table_addr, &register_map_regions, pci_node.name);
+
+        let mut memory_maps = Vec::new();
 
         // 32 bit reserved memory map
         memory_maps.push(MemoryMap::new(
@@ -316,7 +320,10 @@ impl MmioDevice for Pci {
             &PTE_FLAGS_FOR_DEVICE,
         ));
 
-        Self::create_page_table(root_page_table_addr, &register_map_regions, pci_node.name);
+        // map PCI device's register map field
+        if cfg!(feature = "identity_map") {
+            page_table::sv39x4::generate_page_table(root_page_table_addr, &memory_maps);
+        }
 
         Some(Pci {
             register_map_regions,

--- a/hikami_core/src/device/pci.rs
+++ b/hikami_core/src/device/pci.rs
@@ -273,15 +273,6 @@ impl Pci {
     pub fn pci_memory_maps(&self) -> &[MemoryMap] {
         &self.memory_maps
     }
-
-    /// Initialize PCI devices.
-    pub fn init_pci_devices(&self) {
-        if let Some(iommu) = &self.pci_devices.iommu {
-            iommu.init(HostPhysicalAddress(
-                self.register_map_regions[0].starting_address as usize,
-            ));
-        }
-    }
 }
 
 impl MmioDevice for Pci {
@@ -322,7 +313,17 @@ impl MmioDevice for Pci {
 
         // map PCI device's register map field
         if cfg!(feature = "identity_map") {
+            // mapping whole memory mapped register region of block divices.
             page_table::sv39x4::generate_page_table(root_page_table_addr, &memory_maps);
+        }
+
+        // Initialize IOMMU
+        if cfg!(not(feature = "identity_map")) {
+            if let Some(ref iommu) = pci_devices.iommu {
+                iommu.init(HostPhysicalAddress(
+                    register_map_regions[0].starting_address as usize,
+                ));
+            }
         }
 
         Some(Pci {

--- a/hikami_core/src/device/pci.rs
+++ b/hikami_core/src/device/pci.rs
@@ -285,12 +285,13 @@ impl Pci {
 }
 
 impl MmioDevice for Pci {
-    fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let register_map_regions: Vec<MemoryRegion> = device_tree
-            .find_compatible(compatibles)?
-            .reg()
-            .unwrap()
-            .collect();
+    fn try_new(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        compatibles: &[&str],
+    ) -> Option<Self> {
+        let pci_node = device_tree.find_compatible(compatibles)?;
+        let register_map_regions: Vec<MemoryRegion> = pci_node.reg().unwrap().collect();
 
         // assume that pci register contains first region.
         let base_address = HostPhysicalAddress(register_map_regions[0].starting_address as usize);
@@ -314,6 +315,8 @@ impl MmioDevice for Pci {
             pci_addr_space.bit64_memory_space.clone(),
             &PTE_FLAGS_FOR_DEVICE,
         ));
+
+        Self::create_page_table(root_page_table_addr, &register_map_regions, pci_node.name);
 
         Some(Pci {
             register_map_regions,

--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -4,7 +4,7 @@
 use super::{DeviceEmulateError, MmioDevice, PTE_FLAGS_FOR_DEVICE};
 use crate::h_extension::csrs::{VsInterruptKind, hvip};
 use crate::memmap::constant::MAX_HART_NUM;
-use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap};
+use crate::memmap::{GuestPhysicalAddress, HostPhysicalAddress, MemoryMap, page_table};
 
 use alloc::vec::Vec;
 use fdt::{Fdt, standard_nodes::MemoryRegion};
@@ -179,17 +179,50 @@ impl Plic {
 
 impl MmioDevice for Plic {
     #[allow(clippy::cast_ptr_alignment)]
-    fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let register_map_regions: Vec<MemoryRegion> = device_tree
-            .find_compatible(compatibles)?
-            .reg()
-            .unwrap()
-            .collect();
+    fn try_new(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        compatibles: &[&str],
+    ) -> Option<Self> {
+        let plic_node = device_tree.find_compatible(compatibles)?;
+        let register_map_regions: Vec<MemoryRegion> = plic_node.reg().unwrap().collect();
+
+        Self::create_page_table(root_page_table_addr, &register_map_regions, plic_node.name);
 
         Some(Plic {
             register_map_regions,
             claim_complete: [0u32; MAX_CONTEXT_NUM],
         })
+    }
+
+    fn create_page_table(
+        root_page_table_addr: HostPhysicalAddress,
+        memory_regions: &[MemoryRegion],
+        node_name: &str,
+    ) {
+        for (i, map) in memory_regions.iter().enumerate() {
+            crate::println!(
+                "[Device Map] {}{} {:#x}..{:#x}",
+                node_name,
+                i,
+                map.starting_address as usize,
+                map.starting_address as usize + map.size.unwrap(),
+            )
+        }
+        let memory_maps: Vec<MemoryMap> = memory_regions
+            .iter()
+            .cloned()
+            .map(|region| {
+                let virt_start = GuestPhysicalAddress(region.starting_address as usize);
+                let phys_start = HostPhysicalAddress(region.starting_address as usize);
+                MemoryMap::new(
+                    virt_start..virt_start + CONTEXT_BASE,
+                    phys_start..phys_start + CONTEXT_BASE,
+                    &PTE_FLAGS_FOR_DEVICE,
+                )
+            })
+            .collect();
+        page_table::sv39x4::generate_page_table(root_page_table_addr, &memory_maps);
     }
 
     fn memmap(&self) -> Vec<MemoryMap> {

--- a/hikami_core/src/device/rtc.rs
+++ b/hikami_core/src/device/rtc.rs
@@ -1,7 +1,7 @@
 //! RTC: Real Time Clock.
 
 use super::MmioDevice;
-use crate::memmap::MemoryMap;
+use crate::memmap::{HostPhysicalAddress, MemoryMap};
 
 use alloc::vec::Vec;
 use fdt::{Fdt, standard_nodes::MemoryRegion};
@@ -15,12 +15,15 @@ pub struct Rtc {
 }
 
 impl MmioDevice for Rtc {
-    fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let register_map_regions: Vec<MemoryRegion> = device_tree
-            .find_compatible(compatibles)?
-            .reg()
-            .unwrap()
-            .collect();
+    fn try_new(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        compatibles: &[&str],
+    ) -> Option<Self> {
+        let rtc_node = device_tree.find_compatible(compatibles)?;
+        let register_map_regions: Vec<MemoryRegion> = rtc_node.reg().unwrap().collect();
+
+        Self::create_page_table(root_page_table_addr, &register_map_regions, rtc_node.name);
 
         Some(Rtc {
             register_map_regions,

--- a/hikami_core/src/device/sdhci.rs
+++ b/hikami_core/src/device/sdhci.rs
@@ -1,7 +1,7 @@
 //! SDHCI: SD Host Controller Interface
 
 use super::MmioDevice;
-use crate::memmap::MemoryMap;
+use crate::memmap::{HostPhysicalAddress, MemoryMap};
 
 use alloc::vec::Vec;
 use fdt::{Fdt, standard_nodes::MemoryRegion};
@@ -14,12 +14,15 @@ pub struct Mmc {
 }
 
 impl MmioDevice for Mmc {
-    fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let register_map_regions: Vec<MemoryRegion> = device_tree
-            .find_compatible(compatibles)?
-            .reg()
-            .unwrap()
-            .collect();
+    fn try_new(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        compatibles: &[&str],
+    ) -> Option<Self> {
+        let mmc_node = device_tree.find_compatible(compatibles)?;
+        let register_map_regions: Vec<MemoryRegion> = mmc_node.reg().unwrap().collect();
+
+        Self::create_page_table(root_page_table_addr, &register_map_regions, mmc_node.name);
 
         Some(Mmc {
             register_map_regions,

--- a/hikami_core/src/device/uart.rs
+++ b/hikami_core/src/device/uart.rs
@@ -35,12 +35,15 @@ impl Uart {
 }
 
 impl MmioDevice for Uart {
-    fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let register_map_regions: Vec<MemoryRegion> = device_tree
-            .find_compatible(compatibles)?
-            .reg()
-            .unwrap()
-            .collect();
+    fn try_new(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        compatibles: &[&str],
+    ) -> Option<Self> {
+        let uart_node = device_tree.find_compatible(compatibles)?;
+        let register_map_regions: Vec<MemoryRegion> = uart_node.reg().unwrap().collect();
+
+        Self::create_page_table(root_page_table_addr, &register_map_regions, uart_node.name);
 
         UART_ADDR
             .lock()

--- a/hikami_core/src/device/virtio.rs
+++ b/hikami_core/src/device/virtio.rs
@@ -1,7 +1,7 @@
 //! A virtualization standard for network and disk device drivers.
 
 use super::MmioDevice;
-use crate::memmap::MemoryMap;
+use crate::memmap::{HostPhysicalAddress, MemoryMap};
 
 use alloc::vec::Vec;
 use core::slice::Iter;
@@ -14,18 +14,15 @@ pub struct VirtIoList(Vec<VirtIo>);
 
 impl VirtIoList {
     /// Create each Virt IO data when device has multiple IOs.
-    pub fn new(device_tree: &Fdt, node_path: &str) -> Self {
+    pub fn new(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        node_path: &str,
+    ) -> Self {
         VirtIoList(
             device_tree
                 .find_all_nodes(node_path)
-                .map(|node| {
-                    let register_map_regions: Vec<MemoryRegion> = node.reg().unwrap().collect();
-                    let irq = node.property("interrupts").unwrap().value[0];
-                    VirtIo {
-                        register_map_regions,
-                        irq,
-                    }
-                })
+                .map(|virtio_node| VirtIo::new_with_node(root_page_table_addr, &virtio_node))
                 .collect(),
         )
     }

--- a/hikami_core/src/device/virtio.rs
+++ b/hikami_core/src/device/virtio.rs
@@ -5,7 +5,7 @@ use crate::memmap::MemoryMap;
 
 use alloc::vec::Vec;
 use core::slice::Iter;
-use fdt::{Fdt, standard_nodes::MemoryRegion};
+use fdt::{Fdt, node::FdtNode, standard_nodes::MemoryRegion};
 
 /// A virtualization standard for network and disk device drivers.
 /// Since more than one may be found, we will temporarily use the first one.
@@ -46,6 +46,22 @@ pub struct VirtIo {
 }
 
 impl VirtIo {
+    /// Create self with fdt node
+    pub fn new_with_node(root_page_table_addr: HostPhysicalAddress, virtio_node: &FdtNode) -> Self {
+        let register_map_regions: Vec<MemoryRegion> = virtio_node.reg().unwrap().collect();
+
+        Self::create_page_table(
+            root_page_table_addr,
+            &register_map_regions,
+            virtio_node.name,
+        );
+
+        VirtIo {
+            register_map_regions,
+            irq: virtio_node.property("interrupts").unwrap().value[0],
+        }
+    }
+
     /// Return `irq`.
     pub fn irq(&self) -> u8 {
         self.irq
@@ -53,16 +69,12 @@ impl VirtIo {
 }
 
 impl MmioDevice for VirtIo {
-    fn try_new(device_tree: &Fdt, compatibles: &[&str]) -> Option<Self> {
-        let node = device_tree.find_compatible(compatibles)?;
-        let register_map_regions: Vec<MemoryRegion> = node.reg().unwrap().collect();
-
-        let irq = node.property("interrupts").unwrap().value[0];
-
-        Some(VirtIo {
-            register_map_regions,
-            irq,
-        })
+    fn try_new(
+        _root_page_table_addr: HostPhysicalAddress,
+        _device_tree: &Fdt,
+        _compatibles: &[&str],
+    ) -> Option<Self> {
+        unreachable!("use `VirtIo::new_with_node` instead.")
     }
 
     fn memmap(&self) -> Vec<MemoryMap> {

--- a/hikami_core/src/lib.rs
+++ b/hikami_core/src/lib.rs
@@ -47,11 +47,11 @@ impl HypervisorData {
     /// # Panics
     /// It will be panic when parsing device tree failed.
     #[must_use]
-    pub fn new(device_tree: Fdt) -> Self {
+    pub fn new(root_page_table_addr: HostPhysicalAddress, device_tree: Fdt) -> Self {
         HypervisorData {
             current_guest_hart: 0,
             guests: [const { None }; MAX_HART_NUM],
-            devices: Devices::new(device_tree),
+            devices: Devices::new(root_page_table_addr, device_tree),
         }
     }
 

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -160,15 +160,6 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
     // load guest image
     let guest_entry_point = unsafe { new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr()) };
 
-    // initialize IOMMU
-    hypervisor_data
-        .get_mut()
-        .unwrap()
-        .devices()
-        .pci
-        .as_ref()
-        .map(hikami_core::device::pci::Pci::init_pci_devices);
-
     // set new guest data
     hypervisor_data.get_mut().unwrap().register_guest(new_guest);
 

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -141,7 +141,12 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
 
     // initialize hypervisor data
     let mut hypervisor_data = unsafe { HYPERVISOR_DATA.lock() };
-    hypervisor_data.get_or_init(|| HypervisorData::new(device_tree));
+    hypervisor_data.get_or_init(|| {
+        HypervisorData::new(
+            device_tree,
+            HostPhysicalAddress(ROOT_PAGE_TABLE.as_ptr() as usize),
+        )
+    });
 
     // load guest elf `from GUEST_KERNEL`
     let guest_elf = unsafe {

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -155,13 +155,6 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
     // load guest image
     let guest_entry_point = unsafe { new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr()) };
 
-    // set device memory map
-    hypervisor_data
-        .get_mut()
-        .unwrap()
-        .devices()
-        .device_mapping_g_stage(root_page_table_addr);
-
     // initialize IOMMU
     hypervisor_data
         .get_mut()

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -143,8 +143,8 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
     let mut hypervisor_data = unsafe { HYPERVISOR_DATA.lock() };
     hypervisor_data.get_or_init(|| {
         HypervisorData::new(
-            device_tree,
             HostPhysicalAddress(ROOT_PAGE_TABLE.as_ptr() as usize),
+            device_tree,
         )
     });
 


### PR DESCRIPTION
Previously, This hypervisor maps a device register region after `HypervisorData` is initialized, but this can do before the initialization.
This PR changes the initialization order (initialize in `Device::try_new` or other constructor) and output mapping logs.

> [!CAUTION]
> It does not work with IOMMU at this time and need to fix one.