### PR TITLE
 Remap virtual HART ID to physical HART ID in the plic emulation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,7 @@ qemu-system-riscv64
 -machine virt
 -bios default
 -nographic
+-smp 4
 -m 2G
 -drive file=rootfs.ext2,format=raw,id=hd0,if=none
 -device ich9-ahci,id=ahci -device ide-hd,drive=hd0,bus=ahci.0 

--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -26,7 +26,7 @@ const THRESHOLD_CLAIM_SIZE_PER_CONTEXT: usize = 0x1000;
 const CLAIM_OFFSET: usize = 0x4;
 /// End of context registers region.
 const THRESHOLD_CLAIM_END: usize =
-    THRESHOLD_CLAIM_BASE * THRESHOLD_CLAIM_SIZE_PER_CONTEXT * MAX_CONTEXT_NUM;
+    THRESHOLD_CLAIM_BASE + THRESHOLD_CLAIM_SIZE_PER_CONTEXT * MAX_CONTEXT_NUM;
 
 /// PLIC context ID.
 pub struct ContextId(usize);

--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -77,8 +77,9 @@ impl Plic {
     }
 
     /// Emulate reading plic context register
-    fn context_load(&self, offset: usize) -> Result<u32, DeviceEmulateError> {
-        let context_id = (offset - CONTEXT_BASE) / CONTEXT_REGS_SIZE;
+    fn context_load(&self, hart_id: usize, offset: usize) -> Result<u32, DeviceEmulateError> {
+        let guest_context_id = (offset - CONTEXT_BASE) / CONTEXT_REGS_SIZE;
+        let context_id = hart_id * 2 + guest_context_id % 2;
         let offset_per_context = offset % CONTEXT_REGS_SIZE;
         match offset_per_context {
             // threshold
@@ -101,6 +102,7 @@ impl Plic {
     /// It will return an error if `dst_addr` is out of range.
     pub fn emulate_loading(
         &self,
+        hart_id: usize,
         dst_addr: HostPhysicalAddress,
     ) -> Result<u32, DeviceEmulateError> {
         if !(self.base_addr()..self.base_addr() + self.size()).contains(&dst_addr) {
@@ -109,7 +111,7 @@ impl Plic {
 
         let offset = dst_addr.raw() - self.base_addr().raw();
         match offset {
-            CONTEXT_BASE..=CONTEXT_END => self.context_load(offset),
+            CONTEXT_BASE..=CONTEXT_END => self.context_load(hart_id, offset),
             _ => Err(DeviceEmulateError::InvalidAddress),
         }
     }
@@ -120,16 +122,24 @@ impl Plic {
     /// It will return an error if `dst_addr` is out of range.
     fn context_storing(
         &mut self,
+        hart_id: usize,
+        guest_hart_id: usize,
         dst_addr: HostPhysicalAddress,
         value: u32,
     ) -> Result<(), DeviceEmulateError> {
         let offset = dst_addr.raw() - self.base_addr().raw();
-        let context_id = (offset - CONTEXT_BASE) / CONTEXT_REGS_SIZE;
+        let guest_context_id = (offset - CONTEXT_BASE) / CONTEXT_REGS_SIZE;
+        let context_id = hart_id * 2 + guest_context_id % 2;
+
+        assert_eq!(guest_hart_id, guest_context_id / 2);
+
         let offset_per_context = offset % CONTEXT_REGS_SIZE;
+        let phys_hart_ptr =
+            self.base_addr() + CONTEXT_BASE + context_id * CONTEXT_REGS_SIZE + offset_per_context;
         match offset_per_context {
             // threshold
             0 => {
-                let dst_ptr = dst_addr.raw() as *mut u32;
+                let dst_ptr = phys_hart_ptr.raw() as *mut u32;
                 unsafe {
                     dst_ptr.write_volatile(value);
                 }
@@ -138,7 +148,7 @@ impl Plic {
             }
             // claim/complete
             4 => {
-                let dst_ptr = dst_addr.raw() as *mut u32;
+                let dst_ptr = phys_hart_ptr.raw() as *mut u32;
                 unsafe {
                     if self.claim_complete[context_id] == value {
                         self.claim_complete[context_id] = 0;
@@ -162,6 +172,8 @@ impl Plic {
     /// It will return an error if `dst_addr` is out of range.
     pub fn emulate_storing(
         &mut self,
+        hart_id: usize,
+        guest_hart_id: usize,
         dst_addr: HostPhysicalAddress,
         value: u32,
     ) -> Result<(), DeviceEmulateError> {
@@ -171,7 +183,9 @@ impl Plic {
 
         let offset = dst_addr.raw() - self.base_addr().raw();
         match offset {
-            CONTEXT_BASE..=CONTEXT_END => self.context_storing(dst_addr, value),
+            CONTEXT_BASE..=CONTEXT_END => {
+                self.context_storing(hart_id, guest_hart_id, dst_addr, value)
+            }
             _ => Err(DeviceEmulateError::InvalidAddress),
         }
     }

--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -17,6 +17,7 @@ pub const MAX_CONTEXT_NUM: usize = MAX_HART_NUM * 2;
 const ENABLE_BASE: usize = 0x2000;
 /// Context registers region size.
 const ENABLE_SIZE_PER_CONTEXT: usize = 0x80;
+const ENABLE_END: usize = ENABLE_BASE + ENABLE_SIZE_PER_CONTEXT * MAX_CONTEXT_NUM;
 
 /// Base offset of context.
 const THRESHOLD_CLAIM_BASE: usize = 0x20_0000;
@@ -84,6 +85,23 @@ impl Plic {
         self.claim_complete[context_id.raw()] = irq;
     }
 
+    /// Emulate loading plic enable register.
+    ///
+    /// Guest OS attempts load enable bits based on virtual hart id.
+    /// Thus we need to convert a loading address.
+    fn enable_load(&self, hart_id: usize, offset: usize) -> Result<u32, DeviceEmulateError> {
+        let guest_context_id = (offset - ENABLE_BASE) / ENABLE_SIZE_PER_CONTEXT;
+        let context_id = hart_id * 2 + guest_context_id % 2;
+        let offset_per_context = offset % ENABLE_SIZE_PER_CONTEXT;
+        let phys_hart_addr = self.base_addr()
+            + ENABLE_BASE
+            + context_id * ENABLE_SIZE_PER_CONTEXT
+            + offset_per_context;
+        let phys_hart_ptr = phys_hart_addr.raw() as *mut u32;
+
+        unsafe { Ok(phys_hart_ptr.read_volatile()) }
+    }
+
     /// Emulate reading plic context register
     fn context_load(&self, hart_id: usize, offset: usize) -> Result<u32, DeviceEmulateError> {
         let guest_context_id = (offset - THRESHOLD_CLAIM_BASE) / THRESHOLD_CLAIM_SIZE_PER_CONTEXT;
@@ -119,9 +137,41 @@ impl Plic {
 
         let offset = dst_addr.raw() - self.base_addr().raw();
         match offset {
+            ENABLE_BASE..ENABLE_END => self.enable_load(hart_id, offset),
             THRESHOLD_CLAIM_BASE..=THRESHOLD_CLAIM_END => self.context_load(hart_id, offset),
             _ => Err(DeviceEmulateError::InvalidAddress),
         }
+    }
+
+    /// Emulate storing plic enable register.
+    ///
+    /// # Errors
+    /// It will return an error if `dst_addr` is out of range.
+    fn enable_storing(
+        &mut self,
+        hart_id: usize,
+        guest_hart_id: usize,
+        dst_addr: HostPhysicalAddress,
+        value: u32,
+    ) -> Result<(), DeviceEmulateError> {
+        let offset = dst_addr.raw() - self.base_addr().raw();
+        let guest_context_id = (offset - ENABLE_BASE) / ENABLE_SIZE_PER_CONTEXT;
+        let context_id = hart_id * 2 + guest_context_id % 2;
+
+        assert_eq!(guest_hart_id, guest_context_id / 2);
+
+        let offset_per_context = offset % ENABLE_SIZE_PER_CONTEXT;
+        let phys_hart_addr = self.base_addr()
+            + ENABLE_BASE
+            + context_id * ENABLE_SIZE_PER_CONTEXT
+            + offset_per_context;
+        let phys_hart_ptr = phys_hart_addr.raw() as *mut u32;
+
+        unsafe {
+            phys_hart_ptr.write_volatile(value);
+        }
+
+        Ok(())
     }
 
     /// Emulate storing plic context register.
@@ -193,6 +243,9 @@ impl Plic {
 
         let offset = dst_addr.raw() - self.base_addr().raw();
         match offset {
+            ENABLE_BASE..=ENABLE_END => {
+                self.enable_storing(hart_id, guest_hart_id, dst_addr, value)
+            }
             THRESHOLD_CLAIM_BASE..=THRESHOLD_CLAIM_END => {
                 self.context_storing(hart_id, guest_hart_id, dst_addr, value)
             }
@@ -239,8 +292,8 @@ impl MmioDevice for Plic {
                 let virt_start = GuestPhysicalAddress(region.starting_address as usize);
                 let phys_start = HostPhysicalAddress(region.starting_address as usize);
                 MemoryMap::new(
-                    virt_start..virt_start + THRESHOLD_CLAIM_BASE,
-                    phys_start..phys_start + THRESHOLD_CLAIM_BASE,
+                    virt_start..virt_start + ENABLE_BASE,
+                    phys_start..phys_start + ENABLE_BASE,
                     &PTE_FLAGS_FOR_DEVICE,
                 )
             })
@@ -258,8 +311,8 @@ impl MmioDevice for Plic {
                 let virt_start = GuestPhysicalAddress(region.starting_address as usize);
                 let phys_start = HostPhysicalAddress(region.starting_address as usize);
                 MemoryMap::new(
-                    virt_start..virt_start + THRESHOLD_CLAIM_BASE,
-                    phys_start..phys_start + THRESHOLD_CLAIM_BASE,
+                    virt_start..virt_start + ENABLE_BASE,
+                    phys_start..phys_start + ENABLE_BASE,
                     &PTE_FLAGS_FOR_DEVICE,
                 )
             })

--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -16,11 +16,15 @@ pub const MAX_CONTEXT_NUM: usize = MAX_HART_NUM * 2;
 /// Base offset of context.
 const CONTEXT_BASE: usize = 0x20_0000;
 /// Context registers region size.
-const CONTEXT_REGS_SIZE: usize = 0x1000;
-/// Claim/complete register offset from `CONTEXT_BASE` + `CONTEXT_REGS_SIZE` * `CONTEXT_REGS_SIZE`.
-const CONTEXT_CLAIM: usize = 0x4;
+/// Base offset of context.
+const THRESHOLD_CLAIM_BASE: usize = 0x20_0000;
+/// Context registers region size.
+const THRESHOLD_CLAIM_SIZE_PER_CONTEXT: usize = 0x1000;
+/// Claim/complete register offset from `THRESHOLD_CLAIM_BASE` + `THRESHOLD_CLAIM_SIZE_PER_CONTEXT` * `THRESHOLD_CLAIM_SIZE_PER_CONTEXT`.
+const CLAIM_OFFSET: usize = 0x4;
 /// End of context registers region.
-const CONTEXT_END: usize = CONTEXT_BASE * CONTEXT_REGS_SIZE * MAX_CONTEXT_NUM;
+const THRESHOLD_CLAIM_END: usize =
+    THRESHOLD_CLAIM_BASE * THRESHOLD_CLAIM_SIZE_PER_CONTEXT * MAX_CONTEXT_NUM;
 
 /// PLIC context ID.
 pub struct ContextId(usize);
@@ -70,17 +74,19 @@ impl Plic {
 
     /// Read plic claim/update register and reflect to `claim_complete`.
     pub fn update_claim_complete(&mut self, context_id: &ContextId) {
-        let claim_complete_addr =
-            self.base_addr() + CONTEXT_BASE + CONTEXT_REGS_SIZE * context_id.raw() + CONTEXT_CLAIM;
+        let claim_complete_addr = self.base_addr()
+            + THRESHOLD_CLAIM_BASE
+            + THRESHOLD_CLAIM_SIZE_PER_CONTEXT * context_id.raw()
+            + CLAIM_OFFSET;
         let irq = unsafe { core::ptr::read_volatile(claim_complete_addr.raw() as *const u32) };
         self.claim_complete[context_id.raw()] = irq;
     }
 
     /// Emulate reading plic context register
     fn context_load(&self, hart_id: usize, offset: usize) -> Result<u32, DeviceEmulateError> {
-        let guest_context_id = (offset - CONTEXT_BASE) / CONTEXT_REGS_SIZE;
+        let guest_context_id = (offset - THRESHOLD_CLAIM_BASE) / THRESHOLD_CLAIM_SIZE_PER_CONTEXT;
         let context_id = hart_id * 2 + guest_context_id % 2;
-        let offset_per_context = offset % CONTEXT_REGS_SIZE;
+        let offset_per_context = offset % THRESHOLD_CLAIM_SIZE_PER_CONTEXT;
         match offset_per_context {
             // threshold
             0 => unreachable!("[may be unreachable] plic threshold read"),
@@ -111,7 +117,7 @@ impl Plic {
 
         let offset = dst_addr.raw() - self.base_addr().raw();
         match offset {
-            CONTEXT_BASE..=CONTEXT_END => self.context_load(hart_id, offset),
+            THRESHOLD_CLAIM_BASE..=THRESHOLD_CLAIM_END => self.context_load(hart_id, offset),
             _ => Err(DeviceEmulateError::InvalidAddress),
         }
     }
@@ -128,14 +134,16 @@ impl Plic {
         value: u32,
     ) -> Result<(), DeviceEmulateError> {
         let offset = dst_addr.raw() - self.base_addr().raw();
-        let guest_context_id = (offset - CONTEXT_BASE) / CONTEXT_REGS_SIZE;
+        let guest_context_id = (offset - THRESHOLD_CLAIM_BASE) / THRESHOLD_CLAIM_SIZE_PER_CONTEXT;
         let context_id = hart_id * 2 + guest_context_id % 2;
 
         assert_eq!(guest_hart_id, guest_context_id / 2);
 
-        let offset_per_context = offset % CONTEXT_REGS_SIZE;
-        let phys_hart_ptr =
-            self.base_addr() + CONTEXT_BASE + context_id * CONTEXT_REGS_SIZE + offset_per_context;
+        let offset_per_context = offset % THRESHOLD_CLAIM_SIZE_PER_CONTEXT;
+        let phys_hart_ptr = self.base_addr()
+            + THRESHOLD_CLAIM_BASE
+            + context_id * THRESHOLD_CLAIM_SIZE_PER_CONTEXT
+            + offset_per_context;
         match offset_per_context {
             // threshold
             0 => {
@@ -183,7 +191,7 @@ impl Plic {
 
         let offset = dst_addr.raw() - self.base_addr().raw();
         match offset {
-            CONTEXT_BASE..=CONTEXT_END => {
+            THRESHOLD_CLAIM_BASE..=THRESHOLD_CLAIM_END => {
                 self.context_storing(hart_id, guest_hart_id, dst_addr, value)
             }
             _ => Err(DeviceEmulateError::InvalidAddress),
@@ -219,7 +227,7 @@ impl MmioDevice for Plic {
                 "[Device Map] {} {:#x}..{:#x}",
                 node_name,
                 map.starting_address as usize,
-                map.starting_address as usize + CONTEXT_BASE,
+                map.starting_address as usize + THRESHOLD_CLAIM_BASE,
             )
         }
         let memory_maps: Vec<MemoryMap> = memory_regions
@@ -229,8 +237,8 @@ impl MmioDevice for Plic {
                 let virt_start = GuestPhysicalAddress(region.starting_address as usize);
                 let phys_start = HostPhysicalAddress(region.starting_address as usize);
                 MemoryMap::new(
-                    virt_start..virt_start + CONTEXT_BASE,
-                    phys_start..phys_start + CONTEXT_BASE,
+                    virt_start..virt_start + THRESHOLD_CLAIM_BASE,
+                    phys_start..phys_start + THRESHOLD_CLAIM_BASE,
                     &PTE_FLAGS_FOR_DEVICE,
                 )
             })
@@ -248,8 +256,8 @@ impl MmioDevice for Plic {
                 let virt_start = GuestPhysicalAddress(region.starting_address as usize);
                 let phys_start = HostPhysicalAddress(region.starting_address as usize);
                 MemoryMap::new(
-                    virt_start..virt_start + CONTEXT_BASE,
-                    phys_start..phys_start + CONTEXT_BASE,
+                    virt_start..virt_start + THRESHOLD_CLAIM_BASE,
+                    phys_start..phys_start + THRESHOLD_CLAIM_BASE,
                     &PTE_FLAGS_FOR_DEVICE,
                 )
             })

--- a/hikami_core/src/device/plic.rs
+++ b/hikami_core/src/device/plic.rs
@@ -14,8 +14,10 @@ use riscv::register::sie;
 pub const MAX_CONTEXT_NUM: usize = MAX_HART_NUM * 2;
 
 /// Base offset of context.
-const CONTEXT_BASE: usize = 0x20_0000;
+const ENABLE_BASE: usize = 0x2000;
 /// Context registers region size.
+const ENABLE_SIZE_PER_CONTEXT: usize = 0x80;
+
 /// Base offset of context.
 const THRESHOLD_CLAIM_BASE: usize = 0x20_0000;
 /// Context registers region size.

--- a/hikami_core/src/guest.rs
+++ b/hikami_core/src/guest.rs
@@ -58,9 +58,6 @@ impl Guest {
         let stack_top_addr = HostPhysicalAddress(core::ptr::addr_of!(crate::_stack_start) as usize);
         let page_table_addr = HostPhysicalAddress(root_page_table.as_ptr() as usize);
 
-        // init page table
-        page_table::sv39x4::initialize_page_table(page_table_addr);
-
         // map guest memory space
         Self::allocate_memory_region(page_table_addr, &memory_region);
 

--- a/hikami_core/src/lib.rs
+++ b/hikami_core/src/lib.rs
@@ -17,13 +17,15 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cell::OnceCell;
 
-use device::Devices;
-use guest::Guest;
-use memmap::HostPhysicalAddress;
-use memmap::constant::MAX_HART_NUM;
-
+use elf::{ElfBytes, endian::AnyEndian};
 use fdt::Fdt;
 use spin::Mutex;
+
+use device::Devices;
+use guest::Guest;
+use memmap::constant::MAX_HART_NUM;
+use memmap::page_table::sv39x4::FIRST_LV_PAGE_TABLE_LEN;
+use memmap::{GuestPhysicalAddress, HostPhysicalAddress, page_table::PageTableEntry};
 
 /// Singleton for this hypervisor.
 pub static mut HYPERVISOR_DATA: Mutex<OnceCell<HypervisorData>> = Mutex::new(OnceCell::new());
@@ -49,6 +51,10 @@ impl HypervisorData {
     #[must_use]
     pub fn new(root_page_table_addr: HostPhysicalAddress, device_tree: Fdt) -> Self {
         HypervisorData {
+            // fix to zero for now
+            //
+            // TODO: save `hart_id` and `guest_hart_id` to `ContextData` and decide current guest
+            // hart id.
             current_guest_hart: 0,
             guests: [const { None }; MAX_HART_NUM],
             devices: Devices::new(root_page_table_addr, device_tree),
@@ -75,14 +81,50 @@ impl HypervisorData {
             .expect("guest data not found")
     }
 
-    /// Add new guest data.
+    /// Create and register new guest.
     ///
     /// # Panics
     /// It will be panic if `hart_id` is greater than `MAX_HART_NUM`.
-    pub fn register_guest(&mut self, new_guest: Guest) {
-        let guest_hart_id = new_guest.guest_hart_id();
-        assert!(guest_hart_id < MAX_HART_NUM);
+    pub fn register_new_guest(
+        &mut self,
+        hart_id: usize,
+        root_page_table: &'static [PageTableEntry; FIRST_LV_PAGE_TABLE_LEN],
+        guest_kernel: &'static [u8],
+        guest_dtb: &'static [u8],
+        guest_initrd: &'static [u8],
+    ) -> (usize, GuestPhysicalAddress) {
+        // decide guest HART ID
+        let guest_hart_id = self
+            .guests
+            .iter()
+            .position(|x| x.is_none())
+            .expect("guests are full");
+
+        // create new guest data
+        let new_guest = Guest::new(
+            hart_id,
+            guest_hart_id,
+            &root_page_table,
+            &guest_dtb,
+            &guest_initrd,
+        );
+
+        // load guest elf `from GUEST_KERNEL`
+        let guest_elf = unsafe {
+            ElfBytes::<AnyEndian>::minimal_parse(core::slice::from_raw_parts(
+                guest_kernel.as_ptr(),
+                guest_kernel.len(),
+            ))
+            .unwrap()
+        };
+
+        // load guest image
+        let guest_entry_point =
+            unsafe { new_guest.load_guest_elf(&guest_elf, guest_kernel.as_ptr()) };
+
         self.guests[guest_hart_id] = Some(new_guest);
+
+        (guest_hart_id, guest_entry_point)
     }
 }
 

--- a/hikami_core/src/lib.rs
+++ b/hikami_core/src/lib.rs
@@ -107,9 +107,9 @@ impl HypervisorData {
         let new_guest = Guest::new(
             hart_id,
             guest_hart_id,
-            &root_page_table,
-            &guest_dtb,
-            &guest_initrd,
+            root_page_table,
+            guest_dtb,
+            guest_initrd,
         );
 
         // load guest elf `from GUEST_KERNEL`

--- a/hikami_core/src/lib.rs
+++ b/hikami_core/src/lib.rs
@@ -25,7 +25,7 @@ use device::Devices;
 use guest::Guest;
 use memmap::constant::MAX_HART_NUM;
 use memmap::page_table::sv39x4::FIRST_LV_PAGE_TABLE_LEN;
-use memmap::{GuestPhysicalAddress, HostPhysicalAddress, page_table::PageTableEntry};
+use memmap::{GuestPhysicalAddress, HostPhysicalAddress, page_table, page_table::PageTableEntry};
 
 /// Singleton for this hypervisor.
 pub static mut HYPERVISOR_DATA: Mutex<OnceCell<HypervisorData>> = Mutex::new(OnceCell::new());
@@ -50,6 +50,9 @@ impl HypervisorData {
     /// It will be panic when parsing device tree failed.
     #[must_use]
     pub fn new(root_page_table_addr: HostPhysicalAddress, device_tree: Fdt) -> Self {
+        // init page table
+        page_table::sv39x4::initialize_page_table(root_page_table_addr);
+
         HypervisorData {
             // fix to zero for now
             //

--- a/src/hypervisor_init.rs
+++ b/src/hypervisor_init.rs
@@ -2,7 +2,6 @@
 
 use crate::trap::hstrap_vector;
 use crate::{ALLOCATOR, GUEST_DTB, GUEST_INITRD, GUEST_KERNEL};
-use hikami_core::guest::Guest;
 use hikami_core::guest::context::ContextData;
 use hikami_core::h_extension::csrs::{
     VsInterruptKind, hcounteren, hedeleg, hedeleg::ExceptionKind, hgatp, hideleg, hie, hstatus,
@@ -17,7 +16,6 @@ use hikami_core::{HYPERVISOR_DATA, HypervisorData};
 
 use core::arch::asm;
 
-use elf::{ElfBytes, endian::AnyEndian};
 use riscv::register::{sepc, sie, sscratch, sstatus, sstatus::FS, stvec};
 
 /// Entry point to HS-mode.
@@ -121,16 +119,6 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
     hgatp::set(hgatp::Mode::Sv39x4, 0, root_page_table_addr.raw() >> 12);
     hfence_gvma_all();
 
-    // create new guest data
-    let guest_hart_id = 0;
-    let new_guest = Guest::new(
-        hart_id,
-        guest_hart_id,
-        &ROOT_PAGE_TABLE,
-        &GUEST_DTB,
-        &GUEST_INITRD,
-    );
-
     // parse device tree
     let device_tree = unsafe {
         match fdt::Fdt::from_ptr(dtb_addr.raw() as *const u8) {
@@ -148,20 +136,14 @@ fn vsmode_setup(hart_id: usize, dtb_addr: HostPhysicalAddress) -> ! {
         )
     });
 
-    // load guest elf `from GUEST_KERNEL`
-    let guest_elf = unsafe {
-        ElfBytes::<AnyEndian>::minimal_parse(core::slice::from_raw_parts(
-            GUEST_KERNEL.as_ptr(),
-            GUEST_KERNEL.len(),
-        ))
-        .unwrap()
-    };
-
-    // load guest image
-    let guest_entry_point = unsafe { new_guest.load_guest_elf(&guest_elf, GUEST_KERNEL.as_ptr()) };
-
-    // set new guest data
-    hypervisor_data.get_mut().unwrap().register_guest(new_guest);
+    // create and register a new guest
+    let (guest_hart_id, guest_entry_point) = hypervisor_data.get_mut().unwrap().register_new_guest(
+        hart_id,
+        &ROOT_PAGE_TABLE,
+        &GUEST_KERNEL,
+        &GUEST_DTB,
+        &GUEST_INITRD,
+    );
 
     // initialize emulate_extension data
     extension_manager::initialize!();

--- a/src/trap/exception/page_fault_handler.rs
+++ b/src/trap/exception/page_fault_handler.rs
@@ -55,12 +55,13 @@ pub fn load_guest_page_fault() {
     };
 
     let mut hypervisor_data = unsafe { HYPERVISOR_DATA.lock() };
+    let hart_id = hypervisor_data.get().unwrap().guest().hart_id();
     if let Ok(value) = hypervisor_data
         .get_mut()
         .unwrap()
         .devices()
         .plic
-        .emulate_loading(HostPhysicalAddress(fault_addr.raw()))
+        .emulate_loading(hart_id, HostPhysicalAddress(fault_addr.raw()))
     {
         let mut context = hypervisor_data.get().unwrap().guest().context;
         context.set_xreg(fault_inst.rd.expect("rd is not found"), u64::from(value));
@@ -126,7 +127,10 @@ pub fn store_guest_page_fault() {
     };
 
     let mut hypervisor_data = unsafe { HYPERVISOR_DATA.lock() };
-    let mut context = hypervisor_data.get().unwrap().guest().context;
+    let guest = hypervisor_data.get().unwrap().guest();
+    let hart_id = guest.hart_id();
+    let guest_hart_id = guest.guest_hart_id();
+    let mut context = guest.context;
     let store_value = context.xreg(match fault_inst.rs2 {
         Some(x) => x,
         None => panic!("rs2 is not found: {fault_inst:#?} (inst_value: {fault_inst_value})"),
@@ -137,7 +141,12 @@ pub fn store_guest_page_fault() {
         .unwrap()
         .devices()
         .plic
-        .emulate_storing(HostPhysicalAddress(fault_addr.raw()), store_value as u32)
+        .emulate_storing(
+            hart_id,
+            guest_hart_id,
+            HostPhysicalAddress(fault_addr.raw()),
+            store_value as u32,
+        )
     {
         update_sepc_by_inst_type(is_compressed, &mut context);
         return;


### PR DESCRIPTION
A previous change introduced support for multi-core environments by passing a virtualized HART ID, guest_hart_id, from the hypervisor.

However, this introduced a critical problem regarding PLIC emulation.
The guest accesses PLIC's memory-mapped registers using this virtualized HART ID, which does not correspond to the physical HART that the hardware expects. 

This PR resolve the issue by re-mapping virtual HART ID to the correct physical HART ID within the PLIC emulation functions.