### PR TITLE
Add emulation for aclint mswi registers

### DIFF
--- a/hikami_core/src/device/aclint.rs
+++ b/hikami_core/src/device/aclint.rs
@@ -1,5 +1,7 @@
 //! ACLINT: *A*dvanced *C*ore *L*ocal *Int*errupt
 
+mod mswi;
+
 use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
 use crate::memmap::{
     GuestPhysicalAddress, HostPhysicalAddress, MemoryMap, page_table::constants::PAGE_SIZE,
@@ -7,40 +9,6 @@ use crate::memmap::{
 
 use alloc::vec::Vec;
 use fdt::{Fdt, standard_nodes::MemoryRegion};
-
-/// MSWI: Machine level SoftWare Interrupt device
-///
-/// The MSWI device provides machine-level IPI functionality for a set of HARTs on a RISC-V platform.
-/// It has an IPI register (MSIP) for each HART connected to the MSWI device.
-#[derive(Debug)]
-pub struct Mswi {
-    /// Memory maps for memory mapped register.
-    register_map_regions: Vec<MemoryRegion>,
-}
-impl MmioDevice for Mswi {
-    fn try_new(
-        root_page_table_addr: HostPhysicalAddress,
-        device_tree: &Fdt,
-        compatibles: &[&str],
-    ) -> Option<Self> {
-        let clint_node = device_tree.find_compatible(compatibles)?;
-        let register_map_regions: Vec<MemoryRegion> = clint_node.reg().unwrap().collect();
-
-        Self::create_page_table(root_page_table_addr, &register_map_regions, clint_node.name);
-
-        Some(Mswi {
-            register_map_regions,
-        })
-    }
-
-    fn memmap(&self) -> Vec<MemoryMap> {
-        self.register_map_regions
-            .clone()
-            .into_iter()
-            .map(MemoryMap::from)
-            .collect()
-    }
-}
 
 /// MTIMER: Machine level TIMER device
 ///
@@ -100,7 +68,7 @@ impl MmioDevice for Mtimer {
 #[derive(Debug)]
 pub struct Aclint {
     /// MSWI
-    mswi: Mswi,
+    mswi: mswi::Mswi,
     /// MTIMER
     mtimer: Mtimer,
 }
@@ -124,7 +92,7 @@ impl Aclint {
         );
 
         Some(Aclint {
-            mswi: Mswi::try_new(root_page_table_addr, device_tree, mswi_compatibles)?,
+            mswi: mswi::Mswi::try_new(root_page_table_addr, device_tree, mswi_compatibles)?,
             mtimer: Mtimer::try_new(root_page_table_addr, device_tree, mtimer_compatibles)?,
         })
     }

--- a/hikami_core/src/device/aclint.rs
+++ b/hikami_core/src/device/aclint.rs
@@ -27,11 +27,10 @@ impl Aclint {
         mswi_compatibles: &[&str],
         mtimer_compatibles: &[&str],
     ) -> Option<Self> {
-        let mswi_node = device_tree.find_compatible(mswi_compatibles)?;
         let mtimer_node = device_tree.find_compatible(mtimer_compatibles)?;
-        let mut register_map_regions: Vec<MemoryRegion> = mswi_node.reg().unwrap().collect();
-        register_map_regions.append(&mut mtimer_node.reg().unwrap().collect());
+        let register_map_regions: Vec<MemoryRegion> = mtimer_node.reg().unwrap().collect();
 
+        // mswi region won't be mapped.
         Self::create_page_table(
             root_page_table_addr,
             &register_map_regions,

--- a/hikami_core/src/device/aclint.rs
+++ b/hikami_core/src/device/aclint.rs
@@ -1,66 +1,13 @@
 //! ACLINT: *A*dvanced *C*ore *L*ocal *Int*errupt
 
 mod mswi;
+mod mtimer;
 
 use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
-use crate::memmap::{
-    GuestPhysicalAddress, HostPhysicalAddress, MemoryMap, page_table::constants::PAGE_SIZE,
-};
+use crate::memmap::{HostPhysicalAddress, MemoryMap};
 
 use alloc::vec::Vec;
 use fdt::{Fdt, standard_nodes::MemoryRegion};
-
-/// MTIMER: Machine level TIMER device
-///
-/// The MTIMER device provides machine-level timer functionality for a set of HARTs on a RISC-V platform.
-/// It has a single fixed-frequency monotonic time counter (MTIME) register and a time compare register (MTIMECMP) for each HART connected to the MTIMER device.
-/// A MTIMER device not connected to any HART should only have a MTIME register and no MTIMECMP registers.
-#[derive(Debug)]
-pub struct Mtimer {
-    /// Memory maps for memory mapped register.
-    register_map_regions: Vec<MemoryRegion>,
-}
-impl MmioDevice for Mtimer {
-    fn try_new(
-        root_page_table_addr: HostPhysicalAddress,
-        device_tree: &Fdt,
-        compatibles: &[&str],
-    ) -> Option<Self> {
-        let clint_node = device_tree.find_compatible(compatibles)?;
-        let register_map_regions: Vec<MemoryRegion> = clint_node.reg().unwrap().collect();
-
-        Self::create_page_table(root_page_table_addr, &register_map_regions, clint_node.name);
-
-        Some(Mtimer {
-            register_map_regions,
-        })
-    }
-
-    fn memmap(&self) -> Vec<MemoryMap> {
-        self.register_map_regions
-            .clone()
-            .into_iter()
-            .map(|region| {
-                let mut size = region.size.unwrap();
-                let mut virt_start = GuestPhysicalAddress(region.starting_address as usize);
-                let mut phys_start = HostPhysicalAddress(region.starting_address as usize);
-
-                // change memory map region if region size is less than the page size.
-                if phys_start % PAGE_SIZE != 0 && size < PAGE_SIZE {
-                    size = PAGE_SIZE;
-                    virt_start = virt_start - (virt_start % PAGE_SIZE);
-                    phys_start = phys_start - (phys_start % PAGE_SIZE);
-                }
-
-                MemoryMap::new(
-                    virt_start..virt_start + size,
-                    phys_start..phys_start + size,
-                    &PTE_FLAGS_FOR_DEVICE,
-                )
-            })
-            .collect()
-    }
-}
 
 #[allow(clippy::doc_markdown)]
 /// ACLINT: Advanced Core Local INTerrupt
@@ -70,7 +17,7 @@ pub struct Aclint {
     /// MSWI
     mswi: mswi::Mswi,
     /// MTIMER
-    mtimer: Mtimer,
+    mtimer: mtimer::Mtimer,
 }
 
 impl Aclint {
@@ -93,7 +40,7 @@ impl Aclint {
 
         Some(Aclint {
             mswi: mswi::Mswi::try_new(root_page_table_addr, device_tree, mswi_compatibles)?,
-            mtimer: Mtimer::try_new(root_page_table_addr, device_tree, mtimer_compatibles)?,
+            mtimer: mtimer::Mtimer::try_new(root_page_table_addr, device_tree, mtimer_compatibles)?,
         })
     }
 }

--- a/hikami_core/src/device/aclint.rs
+++ b/hikami_core/src/device/aclint.rs
@@ -15,7 +15,7 @@ use fdt::{Fdt, standard_nodes::MemoryRegion};
 #[derive(Debug)]
 pub struct Aclint {
     /// MSWI
-    mswi: mswi::Mswi,
+    pub mswi: mswi::Mswi,
     /// MTIMER
     mtimer: mtimer::Mtimer,
 }

--- a/hikami_core/src/device/aclint/mswi.rs
+++ b/hikami_core/src/device/aclint/mswi.rs
@@ -3,11 +3,14 @@
 //! The MSWI device provides machine-level IPI functionality for a set of HARTs on a RISC-V platform.
 //! It has an IPI register (MSIP) for each HART connected to the MSWI device.
 
-use super::MmioDevice;
+use super::super::{DeviceEmulateError, MmioDevice};
 use crate::memmap::{HostPhysicalAddress, MemoryMap};
 
 use alloc::vec::Vec;
 use fdt::{Fdt, standard_nodes::MemoryRegion};
+
+/// MSWI Register size (4 Bytes)
+const MSWI_REG_SIZE: usize = 0x4;
 
 /// MSWI: Machine level SoftWare Interrupt device
 #[derive(Debug)]
@@ -15,6 +18,74 @@ pub struct Mswi {
     /// Memory maps for memory mapped register.
     register_map_regions: Vec<MemoryRegion>,
 }
+
+impl Mswi {
+    /// Return mswi device base address.
+    fn base_addr(&self) -> HostPhysicalAddress {
+        HostPhysicalAddress(self.register_map_regions[0].starting_address as usize)
+    }
+
+    /// Return mswi device register size
+    fn size(&self) -> usize {
+        self.register_map_regions[0]
+            .size
+            .expect("Mswi does not have size")
+    }
+
+    /// Emulate reading mswi register.
+    ///
+    /// # Errors
+    /// It will return an error if `dst_addr` is out of range.
+    pub fn emulate_loading(
+        &self,
+        hart_id: usize,
+        guest_hart_id: usize,
+        dst_addr: HostPhysicalAddress,
+    ) -> Result<u32, DeviceEmulateError> {
+        if !(self.base_addr()..self.base_addr() + self.size()).contains(&dst_addr) {
+            return Err(DeviceEmulateError::InvalidAddress);
+        }
+
+        let offset = dst_addr.raw() - self.base_addr().raw();
+        let calced_guest_hart_id = offset / MSWI_REG_SIZE;
+
+        assert_eq!(guest_hart_id, calced_guest_hart_id);
+
+        let phys_hart_ptr = (self.base_addr().raw() + hart_id * MSWI_REG_SIZE) as *mut u32;
+
+        unsafe { Ok(phys_hart_ptr.read_volatile()) }
+    }
+
+    /// Emulate storing mswi register.
+    ///
+    /// # Errors
+    /// It will return an error if `dst_addr` is out of range.
+    pub fn emulate_storing(
+        &mut self,
+        hart_id: usize,
+        guest_hart_id: usize,
+        dst_addr: HostPhysicalAddress,
+        value: u32,
+    ) -> Result<(), DeviceEmulateError> {
+        if !(self.base_addr()..self.base_addr() + self.size()).contains(&dst_addr) {
+            return Err(DeviceEmulateError::InvalidAddress);
+        }
+
+        let offset = dst_addr.raw() - self.base_addr().raw();
+        let calced_guest_hart_id = offset / MSWI_REG_SIZE;
+
+        assert_eq!(guest_hart_id, calced_guest_hart_id);
+
+        let phys_hart_ptr = (self.base_addr().raw() + hart_id * MSWI_REG_SIZE) as *mut u32;
+
+        unsafe {
+            phys_hart_ptr.write_volatile(value);
+        }
+
+        Ok(())
+    }
+}
+
 impl MmioDevice for Mswi {
     fn try_new(
         root_page_table_addr: HostPhysicalAddress,

--- a/hikami_core/src/device/aclint/mswi.rs
+++ b/hikami_core/src/device/aclint/mswi.rs
@@ -1,0 +1,41 @@
+//! MSWI: Machine level SoftWare Interrupt device
+//!
+//! The MSWI device provides machine-level IPI functionality for a set of HARTs on a RISC-V platform.
+//! It has an IPI register (MSIP) for each HART connected to the MSWI device.
+
+use super::MmioDevice;
+use crate::memmap::{HostPhysicalAddress, MemoryMap};
+
+use alloc::vec::Vec;
+use fdt::{Fdt, standard_nodes::MemoryRegion};
+
+/// MSWI: Machine level SoftWare Interrupt device
+#[derive(Debug)]
+pub struct Mswi {
+    /// Memory maps for memory mapped register.
+    register_map_regions: Vec<MemoryRegion>,
+}
+impl MmioDevice for Mswi {
+    fn try_new(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        compatibles: &[&str],
+    ) -> Option<Self> {
+        let clint_node = device_tree.find_compatible(compatibles)?;
+        let register_map_regions: Vec<MemoryRegion> = clint_node.reg().unwrap().collect();
+
+        Self::create_page_table(root_page_table_addr, &register_map_regions, clint_node.name);
+
+        Some(Mswi {
+            register_map_regions,
+        })
+    }
+
+    fn memmap(&self) -> Vec<MemoryMap> {
+        self.register_map_regions
+            .clone()
+            .into_iter()
+            .map(MemoryMap::from)
+            .collect()
+    }
+}

--- a/hikami_core/src/device/aclint/mtimer.rs
+++ b/hikami_core/src/device/aclint/mtimer.rs
@@ -1,0 +1,61 @@
+//! MTIMER: Machine level TIMER device
+//!
+//! The MTIMER device provides machine-level timer functionality for a set of HARTs on a RISC-V platform.
+//! It has a single fixed-frequency monotonic time counter (MTIME) register and a time compare register (MTIMECMP) for each HART connected to the MTIMER device.
+//! A MTIMER device not connected to any HART should only have a MTIME register and no MTIMECMP registers.
+
+use super::{MmioDevice, PTE_FLAGS_FOR_DEVICE};
+use crate::memmap::{
+    GuestPhysicalAddress, HostPhysicalAddress, MemoryMap, page_table::constants::PAGE_SIZE,
+};
+
+use alloc::vec::Vec;
+use fdt::{Fdt, standard_nodes::MemoryRegion};
+
+/// MTIMER: Machine level TIMER device
+#[derive(Debug)]
+pub struct Mtimer {
+    /// Memory maps for memory mapped register.
+    register_map_regions: Vec<MemoryRegion>,
+}
+impl MmioDevice for Mtimer {
+    fn try_new(
+        root_page_table_addr: HostPhysicalAddress,
+        device_tree: &Fdt,
+        compatibles: &[&str],
+    ) -> Option<Self> {
+        let clint_node = device_tree.find_compatible(compatibles)?;
+        let register_map_regions: Vec<MemoryRegion> = clint_node.reg().unwrap().collect();
+
+        Self::create_page_table(root_page_table_addr, &register_map_regions, clint_node.name);
+
+        Some(Mtimer {
+            register_map_regions,
+        })
+    }
+
+    fn memmap(&self) -> Vec<MemoryMap> {
+        self.register_map_regions
+            .clone()
+            .into_iter()
+            .map(|region| {
+                let mut size = region.size.unwrap();
+                let mut virt_start = GuestPhysicalAddress(region.starting_address as usize);
+                let mut phys_start = HostPhysicalAddress(region.starting_address as usize);
+
+                // change memory map region if region size is less than the page size.
+                if phys_start % PAGE_SIZE != 0 && size < PAGE_SIZE {
+                    size = PAGE_SIZE;
+                    virt_start = virt_start - (virt_start % PAGE_SIZE);
+                    phys_start = phys_start - (phys_start % PAGE_SIZE);
+                }
+
+                MemoryMap::new(
+                    virt_start..virt_start + size,
+                    phys_start..phys_start + size,
+                    &PTE_FLAGS_FOR_DEVICE,
+                )
+            })
+            .collect()
+    }
+}

--- a/src/trap/exception/page_fault_handler.rs
+++ b/src/trap/exception/page_fault_handler.rs
@@ -56,6 +56,7 @@ pub fn load_guest_page_fault() {
 
     let mut hypervisor_data = unsafe { HYPERVISOR_DATA.lock() };
     let hart_id = hypervisor_data.get().unwrap().guest().hart_id();
+    let guest_hart_id = hypervisor_data.get().unwrap().guest().guest_hart_id();
     if let Ok(value) = hypervisor_data
         .get_mut()
         .unwrap()
@@ -67,6 +68,19 @@ pub fn load_guest_page_fault() {
         context.set_xreg(fault_inst.rd.expect("rd is not found"), u64::from(value));
         update_sepc_by_inst_type(is_compressed, &mut context);
         return;
+    }
+
+    if let Some(aclint) = &mut hypervisor_data.get_mut().unwrap().devices().aclint {
+        if let Ok(value) = aclint.mswi.emulate_loading(
+            hart_id,
+            guest_hart_id,
+            HostPhysicalAddress(fault_addr.raw()),
+        ) {
+            let mut context = hypervisor_data.get().unwrap().guest().context;
+            context.set_xreg(fault_inst.rd.expect("rd is not found"), u64::from(value));
+            update_sepc_by_inst_type(is_compressed, &mut context);
+            return;
+        }
     }
 
     if let Some(pci) = &mut hypervisor_data.get_mut().unwrap().devices().pci {
@@ -150,6 +164,18 @@ pub fn store_guest_page_fault() {
     {
         update_sepc_by_inst_type(is_compressed, &mut context);
         return;
+    }
+
+    if let Some(aclint) = &mut hypervisor_data.get_mut().unwrap().devices().aclint {
+        if let Ok(()) = aclint.mswi.emulate_storing(
+            hart_id,
+            guest_hart_id,
+            HostPhysicalAddress(fault_addr.raw()),
+            store_value as u32,
+        ) {
+            update_sepc_by_inst_type(is_compressed, &mut context);
+            return;
+        }
     }
 
     if let Some(pci) = &mut hypervisor_data.get_mut().unwrap().devices().pci {


### PR DESCRIPTION
A previous change introduced support for multi-core environments by passing a virtualized HART ID, guest_hart_id, from the hypervisor.

However, this also introduced a critical problem regarding MSWI emulation (for PLIC, see #95).
The guest accesses MSWI's memory-mapped registers using this virtualized HART ID, which does not correspond to the physical HART that the hardware expects.

This PR resolve the issue by re-mapping virtual HART ID to the correct physical HART ID within the MSWI emulation functions.

> [!CAUTION]
> The megrez does not access these registers at this time, so I couldn't test for it.